### PR TITLE
chore: improve binance api handling and order status

### DIFF
--- a/binance.js
+++ b/binance.js
@@ -5,7 +5,14 @@ const BASE = process.env.BINANCE_BASE || "https://api.binance.com";
 const API_KEY = process.env.BINANCE_KEY;
 const API_SECRET = process.env.BINANCE_SECRET;
 
+function ensureCreds(){
+  if (!API_KEY || !API_SECRET) {
+    throw new Error("BINANCE_KEY and BINANCE_SECRET env vars are required for signed requests");
+  }
+}
+
 function sign(qs){
+  ensureCreds();
   return crypto.createHmac("sha256", API_SECRET).update(qs).digest("hex");
 }
 
@@ -16,10 +23,12 @@ async function binance(path, method="GET", params={}, signed=false){
   }
   let url = `${BASE}${path}`;
   let body = undefined;
-  const headers = { "X-MBX-APIKEY": API_KEY };
+  const headers = {};
+  if (API_KEY) headers["X-MBX-APIKEY"] = API_KEY;
 
   if (method === "GET"){
     if (signed){
+      ensureCreds();
       urlParams.set("timestamp", Date.now().toString());
       urlParams.set("recvWindow", "5000");
       const sig = sign(urlParams.toString());
@@ -30,6 +39,7 @@ async function binance(path, method="GET", params={}, signed=false){
     }
   } else {
     if (signed){
+      ensureCreds();
       urlParams.set("timestamp", Date.now().toString());
       urlParams.set("recvWindow", "5000");
       const sig = sign(urlParams.toString());

--- a/public/index.html
+++ b/public/index.html
@@ -43,6 +43,14 @@
     </table>
   </div>
 
+  <div class="card">
+    <h3>Open orders</h3>
+    <table id="ordersTable">
+      <thead><tr><th>Symbol</th><th>Side</th><th>Price</th><th>Qty</th><th>Status</th></tr></thead>
+      <tbody></tbody>
+    </table>
+  </div>
+
 <script>
 // Normalize decimals safely: convert "1,5" -> "1.5", trim spaces
 function toNumberSafe(v){
@@ -96,7 +104,27 @@ function render(){
   }
 }
 
+async function loadOrders(){
+  try{
+    const res = await fetch('/api/orders');
+    const arr = await res.json();
+    const tb = document.querySelector('#ordersTable tbody');
+    tb.innerHTML = '';
+    for(const {symbol, orders} of arr){
+      for(const o of orders){
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${symbol}</td><td>${o.side}</td><td>${o.price}</td><td>${o.origQty}</td><td>${o.status}</td>`;
+        tb.appendChild(tr);
+      }
+    }
+  }catch(e){
+    console.error('orders load failed', e);
+  }
+}
+
 load();
+loadOrders();
+setInterval(loadOrders, 5000);
 </script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { runEngine } from "./strategy.js";
+import { openOrders } from "./binance.js";
 
 dotenv.config();
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -78,6 +79,20 @@ res.json({ ok: true, rulesCount: readRules().length });
 } catch {
 res.status(500).json({ ok: false });
 }
+});
+
+app.get("/api/orders", async (req, res) => {
+  try {
+    const rules = readRules();
+    const data = [];
+    for (const r of rules) {
+      const orders = await openOrders(r.symbol);
+      data.push({ symbol: r.symbol, orders });
+    }
+    res.json(data);
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
 });
 
 app.use("/", express.static(path.join(__dirname, "public")));


### PR DESCRIPTION
## Summary
- validate presence of Binance credentials before signing requests
- add API endpoint and UI table to show current open orders

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c44405dc40832b83ea352936b45bfc