### PR TITLE
Rebuild completed trades view as responsive table

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,13 @@ DB_NAME=mybot
 
 # === Binance ===
 BINANCE_BASE=https://api.binance.com
+BINANCE_KEY=
+BINANCE_SECRET=
 MAKER_ONLY=true
+
+# === Completed trades (اختياري) ===
+COMPLETED_TRADES_FETCH_LIMIT=50
+COMPLETED_TRADES_MAX_RESULTS=20
 
 # === OpenAI (اختياري للذكاء الاصطناعي) ===
 OPENAI_API_KEY=

--- a/public/index.html
+++ b/public/index.html
@@ -801,6 +801,190 @@
       white-space: pre-wrap;
     }
 
+    .completed-trades-note {
+      display: none;
+      font-size: 0.85rem;
+      color: var(--muted);
+      margin-bottom: 12px;
+    }
+
+    .completed-trades-note.visible {
+      display: block;
+    }
+
+    .completed-trades-card .table-header {
+      align-items: flex-start;
+      gap: 12px;
+    }
+
+    .completed-trades-wrapper {
+      margin-top: 16px;
+      background: linear-gradient(135deg, rgba(255,255,255,0.95), rgba(241,245,249,0.85));
+      border: 1px solid rgba(148, 163, 184, 0.18);
+      border-radius: 22px;
+      padding: 12px;
+      box-shadow: 0 24px 55px rgba(15, 23, 42, 0.12);
+      overflow: hidden;
+    }
+
+    .completed-trades-table {
+      width: 100%;
+      border-collapse: separate;
+      border-spacing: 0 12px;
+      min-width: 640px;
+    }
+
+    .completed-trades-table thead th {
+      background: transparent;
+      color: rgba(15, 23, 42, 0.6);
+      font-weight: 600;
+      padding-bottom: 0;
+    }
+
+    .completed-trades-table tbody tr {
+      background: rgba(255, 255, 255, 0.96);
+      border-radius: 18px;
+      box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .completed-trades-table tbody tr:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 28px 55px rgba(15, 23, 42, 0.18);
+    }
+
+    .completed-trades-table tbody tr td {
+      border-bottom: none;
+      padding: 18px 20px;
+      vertical-align: top;
+    }
+
+    .completed-trades-table tbody tr td:first-child {
+      border-top-left-radius: 18px;
+      border-bottom-left-radius: 18px;
+    }
+
+    .completed-trades-table tbody tr td:last-child {
+      border-top-right-radius: 18px;
+      border-bottom-right-radius: 18px;
+    }
+
+    .completed-trades-table .pair {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .completed-trades-table .pair-symbol {
+      font-weight: 700;
+      font-size: 1.05rem;
+      letter-spacing: 0.04em;
+    }
+
+    .completed-trades-table .pair-base {
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      color: var(--muted);
+      letter-spacing: 0.08em;
+    }
+
+    .completed-trades-table .status-pill {
+      display: inline-flex;
+      align-items: center;
+      width: max-content;
+      gap: 6px;
+      padding: 4px 10px;
+      border-radius: 999px;
+      background: rgba(37, 99, 235, 0.12);
+      color: var(--accent);
+      font-size: 0.72rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      margin-top: 4px;
+    }
+
+    .completed-trades-table .metric-value {
+      font-weight: 600;
+      font-size: 1rem;
+    }
+
+    .completed-trades-table .metric-sub {
+      font-size: 0.82rem;
+      color: var(--muted);
+      margin-top: 4px;
+    }
+
+    .completed-trades-table .profit-amount {
+      font-size: 1.1rem;
+      font-weight: 700;
+    }
+
+    .completed-trades-table .profit-amount.positive {
+      color: var(--success);
+    }
+
+    .completed-trades-table .profit-amount.negative {
+      color: var(--danger);
+    }
+
+    .completed-trades-table .profit-amount.neutral {
+      color: var(--text);
+    }
+
+    .completed-trades-table .profit-return {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      margin-top: 6px;
+      padding: 4px 10px;
+      border-radius: 999px;
+      background: rgba(37, 99, 235, 0.12);
+      color: var(--accent);
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .completed-trades-table .profit-amount.negative + .profit-return {
+      background: rgba(220, 38, 38, 0.12);
+      color: var(--danger);
+    }
+
+    .completed-trades-table .profit-amount.neutral + .profit-return {
+      background: rgba(148, 163, 184, 0.18);
+      color: var(--muted);
+    }
+
+    .completed-trades-table .cycle {
+      display: grid;
+      gap: 6px;
+      font-size: 0.85rem;
+      color: var(--muted);
+    }
+
+    .completed-trades-table .cycle span {
+      display: inline-flex;
+      gap: 6px;
+      align-items: baseline;
+    }
+
+    .completed-trades-table .cycle strong {
+      color: var(--text);
+      font-weight: 600;
+    }
+
+    .empty-state {
+      padding: 28px 22px;
+      border-radius: 18px;
+      border: 1px dashed rgba(148, 163, 184, 0.4);
+      background: rgba(15, 23, 42, 0.03);
+      text-align: center;
+      font-weight: 500;
+      color: var(--muted);
+    }
+
     .rule-error {
       margin-top: 8px;
       padding: 10px 12px;
@@ -833,6 +1017,28 @@
         font-weight: 600;
         color: var(--muted);
         margin-bottom: 4px;
+      }
+      .completed-trades-wrapper {
+        padding: 0;
+        border-radius: 18px;
+        box-shadow: none;
+      }
+      .completed-trades-table {
+        border-spacing: 0;
+      }
+      .completed-trades-table tbody tr {
+        grid-template-columns: 1fr;
+        padding: 16px;
+        box-shadow: none;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        border-radius: 16px;
+        background: rgba(255, 255, 255, 0.96);
+      }
+      .completed-trades-table tbody tr td {
+        padding: 0;
+      }
+      .completed-trades-table .profit-return {
+        justify-content: flex-start;
       }
     }
   </style>
@@ -1106,6 +1312,33 @@
           </table>
         </div>
       </section>
+      <section class="card table-card completed-trades-card">
+        <div class="table-header">
+          <div>
+            <h2 data-i18n="completed.title">Completed trades</h2>
+            <p class="muted small" data-i18n="completed.subtitle">Latest buy &amp; sell cycles with realised profit.</p>
+          </div>
+          <div class="actions">
+            <button class="btn ghost" id="refreshCompletedTrades" type="button" data-i18n="completed.refresh">Refresh</button>
+          </div>
+        </div>
+        <p class="completed-trades-note small" id="completedTradesNotice"></p>
+        <div class="table-wrapper completed-trades-wrapper">
+          <table class="data-table completed-trades-table" id="completedTradesTable">
+            <thead>
+              <tr>
+                <th data-i18n="completed.table.pair">Pair</th>
+                <th data-i18n="completed.table.quantity">Quantity</th>
+                <th data-i18n="completed.table.avgBuy">Avg buy</th>
+                <th data-i18n="completed.table.avgSell">Avg sell</th>
+                <th data-i18n="completed.table.profit">Profit</th>
+                <th data-i18n="completed.table.cycle">Cycle</th>
+              </tr>
+            </thead>
+            <tbody id="completedTradesList"></tbody>
+          </table>
+        </div>
+      </section>
     </main>
   </div>
 
@@ -1228,6 +1461,32 @@
           },
           empty: "No open orders right now."
         },
+        completed: {
+          title: "Completed trades",
+          subtitle: "Latest buy & sell cycles with realised profit.",
+          refresh: "Refresh",
+          status: "Completed",
+          closed: "Closed",
+          opened: "Opened",
+          duration: "Duration",
+          instant: "Instant",
+          empty: "No completed trades yet.",
+          table: {
+            pair: "Pair",
+            quantity: "Quantity",
+            avgBuy: "Avg buy",
+            avgSell: "Avg sell",
+            profit: "Profit",
+            cycle: "Cycle"
+          },
+          labels: {
+            quantity: "Quantity",
+            avgBuy: "Avg buy",
+            avgSell: "Avg sell",
+            profit: "Profit",
+            return: "Return"
+          }
+        },
         manualRules: {
           buyOnDipLabel: "Buy on dip:",
           takeProfitLabel: "Take profit:",
@@ -1252,6 +1511,7 @@
           manualSynced: "Rules synced with engine.",
           aiGenerated: "AI rule generated successfully.",
           ordersRefreshed: "Open orders refreshed.",
+          completedRefreshed: "Completed trades updated.",
           ruleActivated: "Rule enabled.",
           rulePaused: "Rule paused.",
           ruleDeleted: "Rule deleted.",
@@ -1413,6 +1673,32 @@
           },
           empty: "لا توجد أوامر مفتوحة حاليًا."
         },
+        completed: {
+          title: "الصفقات المكتملة",
+          subtitle: "أحدث دورات الشراء والبيع مع صافي الربح المحقق.",
+          refresh: "تحديث",
+          status: "مكتملة",
+          closed: "أُغلقت",
+          opened: "وقت الفتح",
+          duration: "المدة",
+          instant: "فوري",
+          empty: "لا توجد صفقات مكتملة بعد.",
+          table: {
+            pair: "الزوج",
+            quantity: "الكمية",
+            avgBuy: "متوسط الشراء",
+            avgSell: "متوسط البيع",
+            profit: "الربح",
+            cycle: "الجدول الزمني"
+          },
+          labels: {
+            quantity: "الكمية",
+            avgBuy: "متوسط الشراء",
+            avgSell: "متوسط البيع",
+            profit: "الربح",
+            return: "العائد"
+          }
+        },
         manualRules: {
           buyOnDipLabel: "الشراء عند الانخفاض:",
           takeProfitLabel: "جني الربح:",
@@ -1437,6 +1723,7 @@
           manualSynced: "تمت مزامنة القواعد مع المحرك.",
           aiGenerated: "تم توليد قاعدة ذكاء اصطناعي بنجاح.",
           ordersRefreshed: "تم تحديث الأوامر المفتوحة.",
+          completedRefreshed: "تم تحديث الصفقات المكتملة.",
           ruleActivated: "تم تفعيل القاعدة.",
           rulePaused: "تم إيقاف القاعدة.",
           ruleDeleted: "تم حذف القاعدة.",
@@ -1496,6 +1783,9 @@
       statusTimer: null,
       hasKeys: false,
       isOrdersLoading: false,
+      completedTrades: [],
+      completedTradesErrors: [],
+      isCompletedTradesLoading: false,
       lastRuleErrorsDigest: ''
     };
 
@@ -1527,9 +1817,13 @@
     const manualTableBody = document.querySelector('#manualRulesTable tbody');
     const aiTableBody = document.querySelector('#aiRulesTable tbody');
     const ordersTableBody = document.querySelector('#ordersTable tbody');
+    const completedTradesTable = document.getElementById('completedTradesTable');
+    const completedTradesList = document.getElementById('completedTradesList');
+    const completedTradesNotice = document.getElementById('completedTradesNotice');
     const manualCountEl = document.getElementById('manualCount');
     const aiCountEl = document.getElementById('aiCount');
     const refreshOrdersBtn = document.getElementById('refreshOrders');
+    const refreshCompletedBtn = document.getElementById('refreshCompletedTrades');
     const languageToggle = document.getElementById('languageToggle');
     const pricingGrid = document.getElementById('pricingGrid');
     const dashboardPlansGrid = document.getElementById('dashboardPlans');
@@ -1601,6 +1895,7 @@
       renderSubscription();
       renderTables();
       renderOrders(currentOrdersCache);
+      renderCompletedTrades(state.completedTrades, state.completedTradesErrors);
     }
 
     function setStatus(message, type = 'info') {
@@ -1748,6 +2043,49 @@
       const date = new Date(value);
       if (Number.isNaN(date.getTime())) return '-';
       return date.toLocaleDateString(state.language === 'ar' ? 'ar-EG' : undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+    }
+
+    function formatAsset(amount, asset) {
+      const value = formatNumber(amount);
+      if (value === '-') return '-';
+      return asset ? `${value} ${asset}` : value;
+    }
+
+    function formatSignedCurrency(value, asset) {
+      const num = Number(value);
+      if (!Number.isFinite(num)) return '-';
+      const abs = formatNumber(Math.abs(num));
+      const sign = num > 0 ? '+' : num < 0 ? '-' : '';
+      return `${sign}${abs}${asset ? ` ${asset}` : ''}`.trim();
+    }
+
+    function formatSignedPercent(value) {
+      const num = Number(value);
+      if (!Number.isFinite(num)) return '-';
+      const abs = Math.abs(num).toFixed(2);
+      const sign = num > 0 ? '+' : num < 0 ? '-' : '';
+      return `${sign}${abs}%`;
+    }
+
+    function formatDuration(ms) {
+      const num = Number(ms);
+      if (!Number.isFinite(num) || num <= 0) {
+        return translate('completed.instant');
+      }
+      const totalSeconds = Math.floor(num / 1000);
+      const days = Math.floor(totalSeconds / 86400);
+      const hours = Math.floor((totalSeconds % 86400) / 3600);
+      const minutes = Math.floor((totalSeconds % 3600) / 60);
+      const seconds = totalSeconds % 60;
+      const labels = state.language === 'ar'
+        ? { day: 'ي', hour: 'س', minute: 'د', second: 'ث' }
+        : { day: 'd', hour: 'h', minute: 'm', second: 's' };
+      const parts = [];
+      if (days) parts.push(`${days}${labels.day}`);
+      if (hours) parts.push(`${hours}${labels.hour}`);
+      if (minutes) parts.push(`${minutes}${labels.minute}`);
+      if (!parts.length && seconds) parts.push(`${seconds}${labels.second}`);
+      return parts.length ? parts.slice(0, 2).join(' ') : translate('completed.instant');
     }
 
     function resolveRuleError(rule) {
@@ -1905,6 +2243,97 @@
           `;
           ordersTableBody.appendChild(tr);
         }
+      }
+    }
+
+    function renderCompletedTrades(rows, errors = []) {
+      state.completedTrades = Array.isArray(rows) ? rows : [];
+      state.completedTradesErrors = Array.isArray(errors) ? errors : [];
+
+      if (completedTradesNotice) {
+        if (state.completedTradesErrors.length) {
+          completedTradesNotice.textContent = state.completedTradesErrors.join(' • ');
+          completedTradesNotice.classList.add('visible');
+        } else {
+          completedTradesNotice.textContent = '';
+          completedTradesNotice.classList.remove('visible');
+        }
+      }
+
+      if (!completedTradesList) return;
+      completedTradesList.innerHTML = '';
+
+      const columnCount = completedTradesTable ? completedTradesTable.querySelectorAll('thead th').length : 0;
+
+      if (!state.completedTrades.length) {
+        const tr = document.createElement('tr');
+        tr.className = 'empty-row';
+        const td = document.createElement('td');
+        td.colSpan = columnCount || 6;
+        td.textContent = translate('completed.empty');
+        tr.appendChild(td);
+        completedTradesList.appendChild(tr);
+        return;
+      }
+
+      const pairLabel = translate('completed.table.pair');
+      const quantityLabel = translate('completed.table.quantity');
+      const avgBuyLabel = translate('completed.table.avgBuy');
+      const avgSellLabel = translate('completed.table.avgSell');
+      const profitLabel = translate('completed.table.profit');
+      const cycleLabel = translate('completed.table.cycle');
+      const statusLabel = translate('completed.status');
+      const openedLabel = translate('completed.opened');
+      const closedLabel = translate('completed.closed');
+      const durationLabel = translate('completed.duration');
+      const returnLabel = translate('completed.labels.return');
+
+      for (const trade of state.completedTrades) {
+        if (!trade || typeof trade !== 'object') continue;
+
+        const quantity = formatAsset(trade.quantity, trade.baseAsset);
+        const buyPrice = formatAsset(trade.buyPrice, trade.quoteAsset);
+        const sellPrice = formatAsset(trade.sellPrice, trade.quoteAsset);
+        const profitValue = formatSignedCurrency(trade.profit, trade.quoteAsset);
+        const profitPercent = formatSignedPercent(trade.profitPct);
+        const profitClass = trade.profit > 0 ? 'positive' : trade.profit < 0 ? 'negative' : 'neutral';
+        const openedAt = formatDate(trade.openedAt);
+        const closedAt = formatDate(trade.closedAt);
+        const duration = formatDuration(trade.durationMs);
+        const pairMeta = [trade.baseAsset, trade.quoteAsset].filter(Boolean).join(' / ');
+        const returnText = profitPercent === '-' ? '' : `${returnLabel} · ${profitPercent}`;
+
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td data-label="${escapeHtml(pairLabel)}">
+            <div class="pair">
+              <span class="pair-symbol">${escapeHtml(trade.symbol || '')}</span>
+              ${pairMeta ? `<span class="pair-base">${escapeHtml(pairMeta)}</span>` : ''}
+              <span class="status-pill">${escapeHtml(statusLabel)}</span>
+            </div>
+          </td>
+          <td data-label="${escapeHtml(quantityLabel)}">
+            <span class="metric-value">${escapeHtml(quantity)}</span>
+          </td>
+          <td data-label="${escapeHtml(avgBuyLabel)}">
+            <span class="metric-value">${escapeHtml(buyPrice)}</span>
+          </td>
+          <td data-label="${escapeHtml(avgSellLabel)}">
+            <span class="metric-value">${escapeHtml(sellPrice)}</span>
+          </td>
+          <td data-label="${escapeHtml(profitLabel)}">
+            <span class="profit-amount ${profitClass}">${escapeHtml(profitValue)}</span>
+            ${returnText ? `<span class="profit-return">${escapeHtml(returnText)}</span>` : ''}
+          </td>
+          <td data-label="${escapeHtml(cycleLabel)}">
+            <div class="cycle">
+              <span><strong>${escapeHtml(openedLabel)}:</strong> ${escapeHtml(openedAt)}</span>
+              <span><strong>${escapeHtml(closedLabel)}:</strong> ${escapeHtml(closedAt)}</span>
+              <span><strong>${escapeHtml(durationLabel)}:</strong> ${escapeHtml(duration)}</span>
+            </div>
+          </td>
+        `;
+        completedTradesList.appendChild(tr);
       }
     }
 
@@ -2385,6 +2814,7 @@
         await loadPlans();
         await loadRules();
         await loadOrders();
+        await loadCompletedTrades(true);
         await refreshApiKeysStatus();
         if (state.ordersTimer) clearInterval(state.ordersTimer);
         state.ordersTimer = setInterval(() => loadOrders(true), 8000);
@@ -2439,6 +2869,24 @@
       } finally {
         await refreshRuleErrors();
         state.isOrdersLoading = false;
+      }
+    }
+
+    async function loadCompletedTrades(silent) {
+      if (state.isCompletedTradesLoading) return;
+      state.isCompletedTradesLoading = true;
+      try {
+        const data = await api('/api/trades/completed');
+        const trades = Array.isArray(data?.trades) ? data.trades : [];
+        const errors = Array.isArray(data?.errors) ? data.errors : [];
+        renderCompletedTrades(trades, errors);
+        if (!silent) setStatus(translate('status.completedRefreshed'), 'info');
+      } catch (err) {
+        console.error('completed trades error', err);
+        renderCompletedTrades([], [err.message]);
+        setStatus(err.message, 'error');
+      } finally {
+        state.isCompletedTradesLoading = false;
       }
     }
 
@@ -2651,10 +3099,14 @@
       state.rules = [];
       state.hasKeys = false;
       state.lastRuleErrorsDigest = '';
+      state.completedTrades = [];
+      state.completedTradesErrors = [];
+      state.isCompletedTradesLoading = false;
       if (state.ordersTimer) clearInterval(state.ordersTimer);
       updateEntitlements(null);
       renderTables();
       renderOrders([]);
+      renderCompletedTrades([]);
       showLanding();
     }
 
@@ -2706,6 +3158,7 @@
     syncRulesBtn.addEventListener('click', syncRules);
     aiForm.addEventListener('submit', generateAiRule);
     refreshOrdersBtn.addEventListener('click', () => loadOrders());
+    refreshCompletedBtn.addEventListener('click', () => loadCompletedTrades());
     languageToggle.addEventListener('click', () => {
       setLanguage(state.language === 'ar' ? 'en' : 'ar');
     });
@@ -2716,6 +3169,7 @@
       applyTranslations();
       renderTables();
       renderOrders([]);
+      renderCompletedTrades([]);
       await loadPlans();
       if (state.token) {
         try {

--- a/server.js
+++ b/server.js
@@ -133,6 +133,151 @@ const DEFAULT_AI_BUDGET = (() => {
   return Number.isFinite(raw) && raw > 0 ? raw : 100;
 })();
 
+const COMPLETED_TRADES_FETCH_LIMIT = (() => {
+  const raw = Number(process.env.COMPLETED_TRADES_FETCH_LIMIT);
+  if (!Number.isFinite(raw)) return 50;
+  const normalized = Math.floor(raw);
+  return Math.min(Math.max(normalized, 1), 1000);
+})();
+
+const COMPLETED_TRADES_MAX_RESULTS = (() => {
+  const raw = Number(process.env.COMPLETED_TRADES_MAX_RESULTS);
+  if (!Number.isFinite(raw)) return 20;
+  const normalized = Math.floor(raw);
+  return Math.min(Math.max(normalized, 1), 200);
+})();
+
+const KNOWN_QUOTE_ASSETS = [
+  "USDT",
+  "USDC",
+  "BUSD",
+  "FDUSD",
+  "TUSD",
+  "USDP",
+  "DAI",
+  "BIDR",
+  "TRY",
+  "EUR",
+  "BTC",
+  "ETH",
+  "BNB"
+];
+
+function splitSymbolPair(symbol) {
+  if (!symbol) return { base: "", quote: "" };
+  const upper = String(symbol).toUpperCase();
+  for (const quote of KNOWN_QUOTE_ASSETS) {
+    if (upper.endsWith(quote) && upper.length > quote.length) {
+      return { base: upper.slice(0, upper.length - quote.length), quote };
+    }
+  }
+  const fallbackIndex = Math.max(3, upper.length - 4);
+  return {
+    base: upper.slice(0, fallbackIndex),
+    quote: upper.slice(fallbackIndex)
+  };
+}
+
+function toFiniteNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : 0;
+}
+
+function summariseCompletedTrades(trades, symbol) {
+  if (!Array.isArray(trades) || !trades.length) return [];
+  const { base, quote } = splitSymbolPair(symbol || "");
+  const sorted = [...trades].sort((a, b) => Number(a?.time || 0) - Number(b?.time || 0));
+  const results = [];
+  const EPSILON = 1e-8;
+  let position = null;
+
+  for (const trade of sorted) {
+    const isBuyer = Boolean(trade?.isBuyer);
+    const price = toFiniteNumber(trade?.price);
+    const qty = toFiniteNumber(trade?.qty ?? trade?.executedQty);
+    const quoteQty = toFiniteNumber(trade?.quoteQty ?? price * qty);
+    const commission = toFiniteNumber(trade?.commission);
+    const commissionAsset = typeof trade?.commissionAsset === "string" ? trade.commissionAsset.toUpperCase() : "";
+    const timestamp = Number(trade?.time || trade?.transactTime || Date.now());
+
+    if (!(qty > 0) || !(quoteQty >= 0)) {
+      continue;
+    }
+
+    if (isBuyer) {
+      if (!position) {
+        position = {
+          baseBought: 0,
+          baseSold: 0,
+          quoteSpent: 0,
+          quoteReceived: 0,
+          firstBuyTime: timestamp,
+          lastTradeTime: timestamp
+        };
+      }
+      position.baseBought += qty;
+      position.quoteSpent += quoteQty;
+      if (commission && commissionAsset === quote) {
+        position.quoteSpent += commission;
+      } else if (commission && commissionAsset === base) {
+        position.baseBought -= commission;
+      }
+      if (!position.firstBuyTime) position.firstBuyTime = timestamp;
+      position.lastTradeTime = timestamp;
+      continue;
+    }
+
+    if (!position) {
+      continue;
+    }
+
+    position.baseSold += qty;
+    position.quoteReceived += quoteQty;
+    if (commission && commissionAsset === quote) {
+      position.quoteReceived -= commission;
+    } else if (commission && commissionAsset === base) {
+      position.baseSold -= commission;
+    }
+    position.lastTradeTime = timestamp;
+
+    if (position.baseBought > EPSILON && position.baseSold >= position.baseBought - EPSILON) {
+      const baseBought = position.baseBought;
+      const baseSold = position.baseSold;
+      const quoteSpent = position.quoteSpent;
+      const quoteReceived = position.quoteReceived;
+
+      if (baseBought > EPSILON && baseSold > EPSILON && Number.isFinite(quoteSpent) && Number.isFinite(quoteReceived)) {
+        const quantity = Math.max(0, Math.min(baseBought, baseSold));
+        if (quantity > EPSILON) {
+          const buyPrice = quoteSpent / baseBought;
+          const sellPrice = quoteReceived / baseSold;
+          const profit = quoteReceived - quoteSpent;
+          const profitPct = quoteSpent !== 0 ? (profit / quoteSpent) * 100 : 0;
+          const openedAt = position.firstBuyTime || timestamp;
+          const closedAt = position.lastTradeTime || timestamp;
+          results.push({
+            symbol: String(symbol || "").toUpperCase(),
+            baseAsset: base,
+            quoteAsset: quote,
+            quantity,
+            buyPrice,
+            sellPrice,
+            profit,
+            profitPct,
+            openedAt,
+            closedAt,
+            durationMs: Math.max(0, closedAt - openedAt)
+          });
+        }
+      }
+
+      position = null;
+    }
+  }
+
+  return results;
+}
+
 function encryptionKey() {
   if (!CREDENTIALS_SECRET) {
     throw new Error("CREDENTIALS_SECRET is required to store Binance credentials");
@@ -1447,6 +1592,42 @@ app.get("/api/orders", authRequired(handleAsync(async (req, res) => {
   }
   res.json(data);
 })));
+
+app.get("/api/trades/completed", authRequired(handleAsync(async (req, res) => {
+  const creds = await getUserApiKeys(req.user.id);
+  if (!creds) {
+    return res.status(400).json({ error: "Connect your Binance API keys first" });
+  }
+
+  const rules = await readRules(req.user.id);
+  const symbols = Array.from(new Set(rules.map(r => (r.symbol || "").toUpperCase()).filter(Boolean)));
+  if (!symbols.length) {
+    return res.json({ trades: [], errors: [] });
+  }
+
+  const client = createBinanceClient({ apiKey: creds.apiKey, apiSecret: creds.apiSecret, fallbackToFile: false });
+  const trades = [];
+  const errors = [];
+
+  for (const symbol of symbols) {
+    try {
+      const history = await client.myTrades(symbol, COMPLETED_TRADES_FETCH_LIMIT);
+      const summaries = summariseCompletedTrades(Array.isArray(history) ? history : [], symbol);
+      if (summaries.length) {
+        trades.push(...summaries);
+      }
+    } catch (err) {
+      errors.push(`${symbol}: ${err.message}`);
+    }
+  }
+
+  trades.sort((a, b) => Number(b?.closedAt || 0) - Number(a?.closedAt || 0));
+
+  res.json({
+    trades: trades.slice(0, COMPLETED_TRADES_MAX_RESULTS),
+    errors
+  });
+}))); 
 
 function parseAiRoleResponse(text) {
   if (!text) throw new Error("AI response was empty.");


### PR DESCRIPTION
## Summary
- redesign the completed trades dashboard section as a responsive data table instead of cards
- refresh translations, formatting helpers, and DOM rendering for the new table layout with status and timing details
- polish styling for the completed trades wrapper across desktop and mobile breakpoints

## Testing
- node --check server.js

------
https://chatgpt.com/codex/tasks/task_e_68cf4f247dc8832b8cc9bea9ecbab135