### PR TITLE
Fix completed trade profits and document payment environment keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ PORT=8080
 ALLOWED_ORIGINS=https://example.com
 JWT_SECRET=replace-with-secure-random
 CREDENTIALS_SECRET=replace-with-another-secret
+APP_BASE_URL=http://localhost:8080
+FRONTEND_URL=
+PUBLIC_URL=
 
 # === Database (MySQL) ===
 DB_HOST=localhost
@@ -18,3 +21,13 @@ MAKER_ONLY=true
 # === OpenAI (اختياري للذكاء الاصطناعي) ===
 OPENAI_API_KEY=
 OPENAI_MODEL=gpt-4o-mini
+
+# === اشتراكات Stripe (اختياري) ===
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+
+# === اشتراكات Cryptomus (اختياري) ===
+CRYPTOMUS_MERCHANT_ID=
+CRYPTOMUS_PAYMENT_KEY=
+CRYPTOMUS_SUCCESS_URL=
+CRYPTOMUS_CANCEL_URL=

--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ npm start
 | `OPENAI_MODEL` | اسم نموذج OpenAI الافتراضي (افتراضي `gpt-4o-mini`). |
 | `BINANCE_BASE` | عنوان واجهة Binance (افتراضي `https://api.binance.com`). |
 | `MAKER_ONLY` | هل يتم استخدام أوامر LIMIT_MAKER بشكل افتراضي (افتراضي `true`). |
+| `APP_BASE_URL` | العنوان الأساسي المستخدم لإنشاء روابط الواجهة وإشعارات الدفع (افتراضي `http://localhost:8080`). |
+| `FRONTEND_URL` | عنوان بديل للواجهة الأمامية في حال نشرها على نطاق مختلف (اختياري). |
+| `PUBLIC_URL` | عنوان عام إضافي تستخدمه بعض الروابط أو رسائل البريد (اختياري). |
+| `STRIPE_SECRET_KEY` | مفتاح Stripe السري لتفعيل بوابة الدفع Stripe. |
+| `STRIPE_WEBHOOK_SECRET` | توقيع Webhook القادم من Stripe للتحقق من الإشعارات. |
+| `CRYPTOMUS_MERCHANT_ID` | معرف التاجر داخل بوابة Cryptomus. |
+| `CRYPTOMUS_PAYMENT_KEY` | مفتاح الدفع/‏API الخاص ببوابة Cryptomus. |
+| `CRYPTOMUS_SUCCESS_URL` | رابط النجاح الذي يتم إعادة التوجيه إليه بعد الدفع عبر Cryptomus. |
+| `CRYPTOMUS_CANCEL_URL` | رابط الإلغاء أو الفشل لعمليات Cryptomus. |
 
 ## بنية قاعدة البيانات
 


### PR DESCRIPTION
## Summary
- update completed trade aggregation to handle quote/base commission conversions and derive accurate profit metrics
- clamp negative intermediate values and use matched quantities when computing average prices
- expose Stripe and Cryptomus configuration in `.env.example` and README so the payment gateways can be configured

## Testing
- `node - <<'NODE' ...` (manual trade summarisation scenarios)


------
https://chatgpt.com/codex/tasks/task_e_68cf58693ae4832bbc1d79b62ad9c66d