### PR TITLE
Remove Binance credential fallback and clarify error messaging

### DIFF
--- a/engine/worker.js
+++ b/engine/worker.js
@@ -42,8 +42,7 @@ function ensureBinanceClient(userId, credentials = {}) {
   }
   const client = createBinanceClient({
     apiKey: credentials.apiKey,
-    apiSecret: credentials.apiSecret,
-    fallbackToFile: false
+    apiSecret: credentials.apiSecret
   });
   binanceCache.set(key, { client, fingerprint });
   return client;

--- a/server.js
+++ b/server.js
@@ -1650,7 +1650,7 @@ app.get("/api/orders", authRequired(handleAsync(async (req, res) => {
   if (!symbols.length) {
     return res.json([]);
   }
-  const client = createBinanceClient({ apiKey: creds.apiKey, apiSecret: creds.apiSecret, fallbackToFile: false });
+  const client = createBinanceClient({ apiKey: creds.apiKey, apiSecret: creds.apiSecret });
   const data = [];
   for (const symbol of symbols) {
     try {
@@ -1675,7 +1675,7 @@ app.get("/api/trades/completed", authRequired(handleAsync(async (req, res) => {
     return res.json({ trades: [], errors: [] });
   }
 
-  const client = createBinanceClient({ apiKey: creds.apiKey, apiSecret: creds.apiSecret, fallbackToFile: false });
+  const client = createBinanceClient({ apiKey: creds.apiKey, apiSecret: creds.apiSecret });
   const trades = [];
   const errors = [];
 


### PR DESCRIPTION
## Summary
- remove file/environment fallback handling from the Binance client so only provided user credentials are used
- update worker and server to stop passing the fallback flag when creating Binance clients
- clarify the credential error message to explicitly require a Binance API key and secret

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d093984ef8832b9e4f128efbde6965