### PR TITLE
Prevent caching of API responses

### DIFF
--- a/server.js
+++ b/server.js
@@ -49,6 +49,24 @@ app.use((req, res, next) => {
   next();
 });
 
+const API_NO_CACHE_PATTERNS = [
+  /^\/api\//,
+  /^\/healthz$/,
+  /^\/api\/health$/,
+  /^\/webhooks\//
+];
+
+app.use((req, res, next) => {
+  const path = typeof req.path === "string" ? req.path : req.url || "";
+  if (API_NO_CACHE_PATTERNS.some(pattern => pattern.test(path))) {
+    res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
+    res.setHeader("Pragma", "no-cache");
+    res.setHeader("Expires", "0");
+    res.setHeader("Surrogate-Control", "no-store");
+  }
+  next();
+});
+
 const dbConfig = {
   host: process.env.DB_HOST || "localhost",
   user: process.env.DB_USER || "root",


### PR DESCRIPTION
## Summary
- add an express middleware that marks API, webhook, and health endpoints as non-cacheable
- ensure CDN/proxy layers always forward those requests instead of serving stale content

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d308a25690832b9f7f9e82fc36ed36