### PR TITLE
Add demo account UI and toggles

### DIFF
--- a/public/demo.html
+++ b/public/demo.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="en" dir="ltr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>MY1 Demo Trading</title>
+  <link rel="stylesheet" href="/styles/main.css">
+</head>
+<body>
+  <div class="site">
+    <header class="site-header">
+      <div class="container">
+        <div class="brand">
+          <span class="logo">MY1</span>
+          <div class="tagline">
+            <strong data-i18n="header.taglineTitle">Smart crypto autopilot</strong>
+            <span data-i18n="header.taglineSubtitle">Designed for modern spot traders.</span>
+          </div>
+        </div>
+        <div class="header-actions">
+          <button id="languageToggle" class="language-toggle" type="button">عربي</button>
+          <a class="ghost-link" href="/" data-i18n="header.demoCta">Back to real account</a>
+        </div>
+      </div>
+    </header>
+
+    <main id="demoDashboard">
+      <div class="dashboard-header">
+        <div>
+          <h1 data-i18n="demo.title">Demo trading cockpit</h1>
+          <p class="muted" data-i18n="demo.subtitle">Preview manual and AI strategies with simulated balances. Everything here runs in training mode.</p>
+        </div>
+      </div>
+
+      <div class="account-switcher" id="accountSwitcher" role="tablist" aria-label="Account mode">
+        <button class="account-switcher__btn" id="accountRealBtn" type="button" data-i18n="accounts.real" aria-pressed="false">Real account</button>
+        <button class="account-switcher__btn is-active" id="accountDemoBtn" type="button" data-i18n="accounts.demo" aria-pressed="true">Demo account</button>
+      </div>
+
+      <article class="card demo-intro">
+        <h2 data-i18n="demo.infoTitle">What is demo mode?</h2>
+        <p data-i18n="demo.infoBody">Use the demo workspace to explore how MY1 behaves without connecting your exchange.</p>
+        <ul class="demo-intro__list">
+          <li data-i18n="demo.infoPoint1">No subscription is required — demo mode is unlocked for every user.</li>
+          <li data-i18n="demo.infoPoint2">Binance keys are not needed; the simulator uses built-in market data.</li>
+          <li data-i18n="demo.infoPoint3">Future updates will let you practice managing rules before going live.</li>
+        </ul>
+      </article>
+
+      <section class="dashboard-grid demo-grid">
+        <article class="card demo-card">
+          <div class="demo-card__header">
+            <span class="pill" data-i18n="demo.badge">Preloaded</span>
+            <h2 data-i18n="demo.manualTitle">Manual rules (demo)</h2>
+          </div>
+          <p data-i18n="demo.manualSubtitle">Test dip-buying and take-profit ideas with simulated capital.</p>
+          <div class="demo-placeholder" data-i18n="demo.manualPlaceholder">Demo manual rules will appear here soon.</div>
+        </article>
+
+        <article class="card demo-card">
+          <div class="demo-card__header">
+            <span class="pill" data-i18n="demo.badge">Preloaded</span>
+            <h2 data-i18n="demo.aiTitle">AI rules (demo)</h2>
+          </div>
+          <p data-i18n="demo.aiSubtitle">Preview AI-generated strategies in a safe sandbox.</p>
+          <div class="demo-placeholder" data-i18n="demo.aiPlaceholder">Demo AI rules will appear here soon.</div>
+        </article>
+
+        <article class="card demo-card">
+          <div class="demo-card__header">
+            <span class="pill" data-i18n="demo.badge">Preloaded</span>
+            <h2 data-i18n="demo.ordersTitle">Open orders (demo)</h2>
+          </div>
+          <p data-i18n="demo.ordersSubtitle">Track how demo orders would execute without risking funds.</p>
+          <div class="demo-placeholder" data-i18n="demo.ordersPlaceholder">Demo open orders will appear here soon.</div>
+        </article>
+
+        <article class="card demo-card">
+          <div class="demo-card__header">
+            <span class="pill" data-i18n="demo.badge">Preloaded</span>
+            <h2 data-i18n="demo.completedTitle">Completed trades (demo)</h2>
+          </div>
+          <p data-i18n="demo.completedSubtitle">Review the outcome of simulated trades once they close.</p>
+          <div class="demo-placeholder" data-i18n="demo.completedPlaceholder">Demo completed trades will appear here soon.</div>
+        </article>
+      </section>
+    </main>
+  </div>
+
+  <script type="module" src="/js/demo.js"></script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -117,6 +117,11 @@
         </div>
       </div>
 
+      <div class="account-switcher" id="accountSwitcher" role="tablist" aria-label="Account mode">
+        <button class="account-switcher__btn is-active" id="accountRealBtn" type="button" data-i18n="accounts.real" aria-pressed="true">Real account</button>
+        <button class="account-switcher__btn" id="accountDemoBtn" type="button" data-i18n="accounts.demo" aria-pressed="false">Demo account</button>
+      </div>
+
       <div id="status" class="status" role="status" aria-live="polite"></div>
 
       <section class="dashboard-grid">

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -5,7 +5,8 @@
         header: {
           taglineTitle: "Smart crypto autopilot",
           taglineSubtitle: "Designed for modern spot traders.",
-          cta: "Explore dashboard"
+          cta: "Explore dashboard",
+          demoCta: "Back to real account"
         },
         hero: {
           title: "Trade smarter with AI-assisted automation",
@@ -52,6 +53,10 @@
           subtitle: "Manage AI ideas, monitor open orders, and keep your Binance link under supervision.",
           welcome: "Welcome",
           logout: "Sign out"
+        },
+        accounts: {
+          real: "Real account",
+          demo: "Demo account"
         },
         api: {
           title: "Connect Binance keys",
@@ -255,7 +260,8 @@
         header: {
           taglineTitle: "طيار آلي ذكي للعملات الرقمية",
           taglineSubtitle: "مصمم لمتداولي السبوت العصريين.",
-          cta: "استكشف اللوحة"
+          cta: "استكشف اللوحة",
+          demoCta: "العودة للحساب الحقيقي"
         },
         hero: {
           title: "تداول بذكاء مع أتمتة مدعومة بالذكاء الاصطناعي",
@@ -302,6 +308,10 @@
           subtitle: "أدر أفكار الذكاء الاصطناعي، راقب الأوامر المفتوحة، وأشرف على ربط Binance.",
           welcome: "مرحبًا",
           logout: "تسجيل الخروج"
+        },
+        accounts: {
+          real: "الحساب الحقيقي",
+          demo: "الحساب التجريبي"
         },
         api: {
           title: "ربط مفاتيح Binance",
@@ -598,6 +608,8 @@
     const mfaTokenInput = document.getElementById('mfaTokenInput');
     const loginMfaRow = document.getElementById('loginMfaRow');
     const loginMfaInput = document.getElementById('loginMfa');
+    const accountRealBtn = document.getElementById('accountRealBtn');
+    const accountDemoBtn = document.getElementById('accountDemoBtn');
 
     function resolveTranslation(lang, key) {
       const fallback = translations.en;
@@ -2297,6 +2309,27 @@
     if (confirmMfaBtn) confirmMfaBtn.addEventListener('click', confirmMfaAction);
     refreshOrdersBtn.addEventListener('click', () => loadOrders());
     refreshCompletedBtn.addEventListener('click', () => loadCompletedTrades());
+    if (accountRealBtn) {
+      accountRealBtn.addEventListener('click', () => {
+        accountRealBtn.classList.add('is-active');
+        accountRealBtn.setAttribute('aria-pressed', 'true');
+        if (accountDemoBtn) {
+          accountDemoBtn.classList.remove('is-active');
+          accountDemoBtn.setAttribute('aria-pressed', 'false');
+        }
+      });
+    }
+    if (accountDemoBtn) {
+      accountDemoBtn.addEventListener('click', () => {
+        accountDemoBtn.classList.add('is-active');
+        accountDemoBtn.setAttribute('aria-pressed', 'true');
+        if (accountRealBtn) {
+          accountRealBtn.classList.remove('is-active');
+          accountRealBtn.setAttribute('aria-pressed', 'false');
+        }
+        window.location.href = '/demo.html';
+      });
+    }
     languageToggle.addEventListener('click', () => {
       setLanguage(state.language === 'ar' ? 'en' : 'ar');
     });

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -1,0 +1,138 @@
+(() => {
+  const translations = {
+    en: {
+      meta: { title: 'MY1 Demo Trading' },
+      header: {
+        taglineTitle: 'Smart crypto autopilot',
+        taglineSubtitle: 'Designed for modern spot traders.',
+        demoCta: 'Back to real account'
+      },
+      accounts: {
+        real: 'Real account',
+        demo: 'Demo account'
+      },
+      demo: {
+        title: 'Demo trading cockpit',
+        subtitle: 'Preview manual and AI strategies with simulated balances. Everything here runs in training mode.',
+        badge: 'Preloaded',
+        infoTitle: 'What is demo mode?',
+        infoBody: 'Use the demo workspace to explore how MY1 behaves without connecting your exchange.',
+        infoPoint1: 'No subscription is required — demo mode is unlocked for every user.',
+        infoPoint2: 'Binance keys are not needed; the simulator uses built-in market data.',
+        infoPoint3: 'Future updates will let you practice managing rules before going live.',
+        manualTitle: 'Manual rules (demo)',
+        manualSubtitle: 'Test dip-buying and take-profit ideas with simulated capital.',
+        manualPlaceholder: 'Demo manual rules will appear here soon.',
+        aiTitle: 'AI rules (demo)',
+        aiSubtitle: 'Preview AI-generated strategies in a safe sandbox.',
+        aiPlaceholder: 'Demo AI rules will appear here soon.',
+        ordersTitle: 'Open orders (demo)',
+        ordersSubtitle: 'Track how demo orders would execute without risking funds.',
+        ordersPlaceholder: 'Demo open orders will appear here soon.',
+        completedTitle: 'Completed trades (demo)',
+        completedSubtitle: 'Review the outcome of simulated trades once they close.',
+        completedPlaceholder: 'Demo completed trades will appear here soon.'
+      }
+    },
+    ar: {
+      meta: { title: 'وضع التداول التجريبي MY1' },
+      header: {
+        taglineTitle: 'طيار آلي ذكي للعملات الرقمية',
+        taglineSubtitle: 'مصمم لمتداولي السبوت العصريين.',
+        demoCta: 'العودة للحساب الحقيقي'
+      },
+      accounts: {
+        real: 'الحساب الحقيقي',
+        demo: 'الحساب التجريبي'
+      },
+      demo: {
+        title: 'قمرة التداول التجريبية',
+        subtitle: 'استكشف القواعد اليدوية والذكاء الاصطناعي بأرصدة افتراضية. كل شيء هنا يعمل في وضع التدريب.',
+        badge: 'افتراضي',
+        infoTitle: 'ما هو الوضع التجريبي؟',
+        infoBody: 'استخدم مساحة العمل التجريبية لمعرفة كيفية عمل MY1 بدون ربط منصتك.',
+        infoPoint1: 'لا حاجة لأي اشتراك — الوضع التجريبي متاح للجميع.',
+        infoPoint2: 'لا يتطلب مفاتيح Binance؛ يعتمد المحاكي على بيانات سوق مدمجة.',
+        infoPoint3: 'تحديثات قادمة ستتيح لك التدرب على إدارة القواعد قبل التفعيل الحقيقي.',
+        manualTitle: 'القواعد اليدوية (تجريبي)',
+        manualSubtitle: 'اختبر أفكار الشراء عند الانخفاض وجني الربح برصيد افتراضي.',
+        manualPlaceholder: 'سيتم عرض القواعد اليدوية التجريبية هنا قريبًا.',
+        aiTitle: 'قواعد الذكاء الاصطناعي (تجريبي)',
+        aiSubtitle: 'استعرض الاستراتيجيات المولدة بالذكاء الاصطناعي في بيئة آمنة.',
+        aiPlaceholder: 'سيتم عرض قواعد الذكاء الاصطناعي التجريبية هنا قريبًا.',
+        ordersTitle: 'الأوامر المفتوحة (تجريبي)',
+        ordersSubtitle: 'تابع كيف ستُنفذ الأوامر التجريبية دون مخاطرة.',
+        ordersPlaceholder: 'سيتم عرض الأوامر المفتوحة التجريبية هنا قريبًا.',
+        completedTitle: 'الصفقات المكتملة (تجريبي)',
+        completedSubtitle: 'راجع نتائج الصفقات التجريبية بعد إغلاقها.',
+        completedPlaceholder: 'سيتم عرض الصفقات المكتملة التجريبية هنا قريبًا.'
+      }
+    }
+  };
+
+  const state = {
+    language: localStorage.getItem('mybot_language') || 'en'
+  };
+
+  const languageToggle = document.getElementById('languageToggle');
+  const accountRealBtn = document.getElementById('accountRealBtn');
+  const accountDemoBtn = document.getElementById('accountDemoBtn');
+
+  function resolveTranslation(lang, key) {
+    const fallback = translations.en;
+    const parts = key.split('.');
+    let target = translations[lang] || translations.en;
+    let fallbackTarget = fallback;
+    for (const part of parts) {
+      target = target && target[part] !== undefined ? target[part] : undefined;
+      fallbackTarget = fallbackTarget && fallbackTarget[part] !== undefined ? fallbackTarget[part] : undefined;
+    }
+    return target !== undefined ? target : fallbackTarget;
+  }
+
+  function applyTranslations() {
+    const lang = state.language === 'ar' ? 'ar' : 'en';
+    document.documentElement.lang = lang;
+    document.documentElement.dir = lang === 'ar' ? 'rtl' : 'ltr';
+    document.title = resolveTranslation(lang, 'meta.title');
+    if (languageToggle) {
+      languageToggle.textContent = lang === 'ar' ? 'English' : 'عربي';
+    }
+    document.querySelectorAll('[data-i18n]').forEach(el => {
+      const key = el.getAttribute('data-i18n');
+      const value = resolveTranslation(lang, key);
+      if (typeof value === 'string') {
+        el.textContent = value;
+      }
+    });
+  }
+
+  function setLanguage(lang) {
+    state.language = lang;
+    localStorage.setItem('mybot_language', state.language);
+    applyTranslations();
+  }
+
+  if (languageToggle) {
+    languageToggle.addEventListener('click', () => {
+      setLanguage(state.language === 'ar' ? 'en' : 'ar');
+    });
+  }
+
+  if (accountRealBtn) {
+    accountRealBtn.addEventListener('click', () => {
+      window.location.href = '/';
+    });
+  }
+
+  if (accountDemoBtn) {
+    accountDemoBtn.classList.add('is-active');
+    accountDemoBtn.setAttribute('aria-pressed', 'true');
+    accountDemoBtn.addEventListener('click', () => {
+      accountDemoBtn.classList.add('is-active');
+      accountDemoBtn.setAttribute('aria-pressed', 'true');
+    });
+  }
+
+  applyTranslations();
+})();

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -347,6 +347,50 @@
       font-size: clamp(1.8rem, 4vw, 2.4rem);
     }
 
+    .account-switcher {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px;
+      border-radius: 999px;
+      background: rgba(37, 99, 235, 0.12);
+      border: 1px solid rgba(37, 99, 235, 0.25);
+      margin-bottom: 32px;
+      flex-wrap: wrap;
+    }
+
+    .account-switcher__btn {
+      border: none;
+      background: transparent;
+      color: var(--accent);
+      font-weight: 600;
+      border-radius: 999px;
+      padding: 10px 22px;
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .account-switcher__btn:hover {
+      background: rgba(37, 99, 235, 0.18);
+      color: var(--accent-dark);
+    }
+
+    .account-switcher__btn.is-active {
+      background: var(--accent);
+      color: #fff;
+      box-shadow: 0 18px 35px rgba(37, 99, 235, 0.35);
+    }
+
+    .account-switcher__btn.is-active:hover {
+      background: var(--accent);
+      color: #fff;
+    }
+
+    .account-switcher__btn:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.35);
+    }
+
     .user-meta {
       display: flex;
       align-items: center;
@@ -372,6 +416,73 @@
       gap: 24px;
       grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
       margin-bottom: 32px;
+    }
+
+    #demoDashboard {
+      padding: clamp(40px, 6vw, 72px) clamp(20px, 8vw, 120px);
+      background: #f5f6fb;
+      min-height: 100vh;
+    }
+
+    .demo-grid {
+      margin-top: 32px;
+    }
+
+    .demo-card__header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 12px;
+    }
+
+    .demo-card__header h2 {
+      margin: 0;
+    }
+
+    .demo-card .pill {
+      flex-shrink: 0;
+    }
+
+    .demo-placeholder {
+      margin-top: 20px;
+      padding: 26px;
+      text-align: center;
+      border-radius: 18px;
+      border: 1px dashed rgba(148, 163, 184, 0.6);
+      background: rgba(15, 23, 42, 0.02);
+      color: var(--muted);
+      font-weight: 500;
+    }
+
+    .demo-intro {
+      margin-bottom: 32px;
+    }
+
+    .demo-intro__list {
+      margin: 16px 0 0;
+      padding: 0;
+      list-style: none;
+      display: grid;
+      gap: 10px;
+    }
+
+    .demo-intro__list li {
+      position: relative;
+      padding-inline-start: 22px;
+      color: var(--muted);
+      font-weight: 500;
+    }
+
+    .demo-intro__list li::before {
+      content: "";
+      position: absolute;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--accent);
+      top: 10px;
+      inset-inline-start: 0;
     }
 
     .card {


### PR DESCRIPTION
## Summary
- add an account mode toggle to the main dashboard so users can switch between real and demo views
- introduce a standalone demo dashboard with placeholder sections for manual rules, AI rules, open orders, and completed trades
- extend translations, styling, and scripts to support the demo experience and account switching

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d46f4953a4832b9b58cc61e92ebcfb