### PR TITLE
Improve account switching navigation and plan display

### DIFF
--- a/public/demo.html
+++ b/public/demo.html
@@ -35,8 +35,8 @@
             </div>
             <div class="dashboard-hero__actions">
               <div class="account-switcher" id="accountSwitcher" role="tablist" aria-label="Account mode">
-                <button class="account-switcher__btn" id="accountRealBtn" type="button" data-i18n="accounts.real" aria-pressed="false">Real account</button>
-                <button class="account-switcher__btn is-active" id="accountDemoBtn" type="button" data-i18n="accounts.demo" aria-pressed="true">Demo account</button>
+                <a class="account-switcher__btn" id="accountRealBtn" href="/" role="tab" data-i18n="accounts.real" aria-selected="false">Real account</a>
+                <a class="account-switcher__btn is-active" id="accountDemoBtn" href="/demo.html" role="tab" data-i18n="accounts.demo" aria-selected="true">Demo account</a>
               </div>
             </div>
           </div>

--- a/public/index.html
+++ b/public/index.html
@@ -165,8 +165,8 @@
             </div>
             <div class="dashboard-hero__actions">
               <div class="account-switcher" id="accountSwitcher" role="tablist" aria-label="Account mode">
-                <button class="account-switcher__btn is-active" id="accountRealBtn" type="button" data-i18n="accounts.real" aria-pressed="true">Real account</button>
-                <button class="account-switcher__btn" id="accountDemoBtn" type="button" data-i18n="accounts.demo" aria-pressed="false">Demo account</button>
+                <a class="account-switcher__btn is-active" id="accountRealBtn" href="/" role="tab" data-i18n="accounts.real" aria-selected="true">Real account</a>
+                <a class="account-switcher__btn" id="accountDemoBtn" href="/demo.html" role="tab" data-i18n="accounts.demo" aria-selected="false">Demo account</a>
               </div>
               <div class="user-meta">
                 <span class="pill" id="welcomeName" data-i18n="dashboard.welcome">Welcome</span>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -293,6 +293,7 @@
           payWithCryptomus: "Pay with crypto (Cryptomus)",
           loginRequired: "Sign in to subscribe to a plan.",
           renewing: "Processing payment confirmation...",
+          billingCycle: "Billing cycle: every {{days}} days",
           historyTitle: "Recent payments",
           historyEmpty: "No subscription history yet.",
           pendingNotice: "Awaiting payment confirmation for {{name}}.",
@@ -597,6 +598,7 @@
           payWithCryptomus: "الدفع بالعملات الرقمية (Cryptomus)",
           loginRequired: "سجل الدخول للاشتراك في باقة.",
           renewing: "جاري تأكيد عملية الدفع...",
+          billingCycle: "دورة الفوترة: كل {{days}} يوم",
           historyTitle: "سجل الدفعات",
           historyEmpty: "لا يوجد سجل دفعات بعد.",
           pendingNotice: "بانتظار تأكيد الدفع لباقـة {{name}}.",
@@ -715,7 +717,8 @@
     const loginMfaInput = document.getElementById('loginMfa');
     const accountRealBtn = document.getElementById('accountRealBtn');
     const accountDemoBtn = document.getElementById('accountDemoBtn');
-    const isDemoPage = window.location.pathname.endsWith('/demo.html');
+    const currentPath = window.location.pathname.toLowerCase();
+    const isDemoPage = currentPath.endsWith('/demo.html') || currentPath === '/demo' || currentPath === '/demo/';
 
     function resolveTranslation(lang, key) {
       const fallback = translations.en;
@@ -1659,6 +1662,7 @@
               : translate('subscription.aiUnlimited'))
           : translate('pricing.aiDisabled');
         const durationText = translate('pricing.duration', { days: plan.durationDays });
+        const billingText = translate('subscription.billingCycle', { days: plan.durationDays });
         const headerParts = [];
         const badges = [];
         const entStatus = (ent.status || '').toLowerCase();
@@ -1681,9 +1685,7 @@
             <div class="plan-price">${escapeHtml(formatUSD(plan.priceUSD))}<span>${escapeHtml(durationText)}</span></div>
           </div>
           <ul class="plan-feature-list">
-            <li>${escapeHtml(manualText)}</li>
-            <li>${escapeHtml(aiText)}</li>
-            <li>${escapeHtml(durationText)}</li>
+            ${[manualText, aiText, billingText].map(item => `<li>${escapeHtml(item)}</li>`).join('')}
           </ul>
         `;
         const actions = document.createElement('div');
@@ -2629,30 +2631,34 @@
     refreshOrdersBtn.addEventListener('click', () => loadOrders());
     refreshCompletedBtn.addEventListener('click', () => loadCompletedTrades());
     if (accountRealBtn) {
-      accountRealBtn.addEventListener('click', () => {
+      accountRealBtn.addEventListener('click', event => {
+        const target = accountRealBtn.getAttribute('href') || '/';
         if (isDemoPage) {
-          window.location.href = '/';
+          window.location.href = target;
           return;
         }
+        event.preventDefault();
         accountRealBtn.classList.add('is-active');
-        accountRealBtn.setAttribute('aria-pressed', 'true');
+        accountRealBtn.setAttribute('aria-selected', 'true');
         if (accountDemoBtn) {
           accountDemoBtn.classList.remove('is-active');
-          accountDemoBtn.setAttribute('aria-pressed', 'false');
+          accountDemoBtn.setAttribute('aria-selected', 'false');
         }
       });
     }
     if (accountDemoBtn) {
-      accountDemoBtn.addEventListener('click', () => {
+      accountDemoBtn.addEventListener('click', event => {
+        const target = accountDemoBtn.getAttribute('href') || '/demo.html';
         if (!isDemoPage) {
-          window.location.href = '/demo.html';
+          window.location.href = target;
           return;
         }
+        event.preventDefault();
         accountDemoBtn.classList.add('is-active');
-        accountDemoBtn.setAttribute('aria-pressed', 'true');
+        accountDemoBtn.setAttribute('aria-selected', 'true');
         if (accountRealBtn) {
           accountRealBtn.classList.remove('is-active');
-          accountRealBtn.setAttribute('aria-pressed', 'false');
+          accountRealBtn.setAttribute('aria-selected', 'false');
         }
       });
     }

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -788,13 +788,22 @@
       });
     }
     if (accountRealBtn) {
-      accountRealBtn.addEventListener('click', () => {
-        window.location.href = '/';
+      accountRealBtn.addEventListener('click', event => {
+        const target = accountRealBtn.getAttribute('href') || '/';
+        const path = window.location.pathname.toLowerCase();
+        if (path.endsWith('/demo.html') || path === '/demo' || path === '/demo/') {
+          return;
+        }
+        event.preventDefault();
+        window.location.href = target;
       });
     }
     if (accountDemoBtn) {
       accountDemoBtn.classList.add('is-active');
-      accountDemoBtn.setAttribute('aria-pressed', 'true');
+      accountDemoBtn.setAttribute('aria-selected', 'true');
+      if (accountRealBtn) {
+        accountRealBtn.setAttribute('aria-selected', 'false');
+      }
     }
     if (manualForm) {
       manualForm.addEventListener('submit', handleManualSubmit);

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -721,72 +721,99 @@
     .account-switcher {
       display: inline-flex;
       align-items: center;
-      gap: 10px;
-      padding: 8px;
+      gap: 12px;
+      padding: 10px;
       border-radius: 999px;
-      background: rgba(99, 102, 241, 0.12);
-      border: 1px solid rgba(99, 102, 241, 0.25);
+      background: linear-gradient(135deg, rgba(99, 102, 241, 0.16), rgba(59, 130, 246, 0.12));
+      border: 1px solid rgba(99, 102, 241, 0.28);
+      box-shadow: 0 22px 48px rgba(79, 70, 229, 0.18);
       flex-wrap: wrap;
     }
 
     .account-switcher__btn {
-      border: none;
-      background: transparent;
-      color: var(--accent);
-      font-weight: 700;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 6px;
+      padding: 14px 32px;
       border-radius: 999px;
-      padding: 12px 26px;
       font-size: 1rem;
+      font-weight: 700;
       letter-spacing: 0.01em;
       cursor: pointer;
-      transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+      text-decoration: none;
+      color: var(--accent);
+      background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(226, 232, 240, 0.88));
+      border: 1px solid rgba(99, 102, 241, 0.4);
+      box-shadow: 0 14px 26px rgba(99, 102, 241, 0.2);
+      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+      min-width: 0;
+    }
+
+    .account-switcher__btn:visited {
+      color: inherit;
     }
 
     .account-switcher__btn:hover {
-      transform: translateY(-1px);
-      background: rgba(99, 102, 241, 0.18);
+      transform: translateY(-2px);
+      background: linear-gradient(135deg, rgba(224, 231, 255, 1), rgba(199, 210, 254, 0.95));
+      border-color: rgba(79, 70, 229, 0.5);
+      box-shadow: 0 18px 32px rgba(79, 70, 229, 0.28);
       color: var(--accent-dark);
     }
 
     .account-switcher__btn.is-active {
-      background: var(--accent);
+      background: linear-gradient(135deg, #4f46e5, #6366f1);
+      border-color: rgba(79, 70, 229, 0.85);
       color: #fff;
-      box-shadow: 0 20px 40px rgba(79, 70, 229, 0.45);
+      box-shadow: 0 24px 38px rgba(79, 70, 229, 0.45);
+      transform: translateY(-1px);
     }
 
     .account-switcher__btn:focus-visible {
       outline: none;
-      box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.35);
+      box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.35), 0 14px 28px rgba(99, 102, 241, 0.2);
+    }
+
+    .account-switcher__btn:active {
+      transform: translateY(0);
     }
 
     .dashboard-hero .account-switcher {
-      background: rgba(255, 255, 255, 0.16);
-      border-color: rgba(255, 255, 255, 0.38);
-      box-shadow: 0 22px 45px rgba(15, 23, 42, 0.35);
+      background: rgba(15, 23, 42, 0.52);
+      border-color: rgba(148, 163, 184, 0.45);
+      box-shadow: 0 26px 52px rgba(15, 23, 42, 0.45);
     }
 
     .dashboard-hero .account-switcher__btn {
-      color: rgba(248, 251, 255, 0.88);
+      color: rgba(226, 232, 240, 0.9);
+      background: linear-gradient(135deg, rgba(30, 41, 59, 0.72), rgba(51, 65, 85, 0.65));
+      border-color: rgba(148, 163, 184, 0.45);
+      box-shadow: 0 16px 32px rgba(15, 23, 42, 0.45);
     }
 
     .dashboard-hero .account-switcher__btn:hover {
-      background: rgba(255, 255, 255, 0.22);
       color: #fff;
+      background: linear-gradient(135deg, rgba(59, 130, 246, 0.45), rgba(99, 102, 241, 0.42));
+      border-color: rgba(148, 163, 184, 0.6);
     }
 
     .dashboard-hero .account-switcher__btn.is-active {
-      background: #f8fafc;
+      background: linear-gradient(135deg, #f8fafc, #e2e8f0);
       color: #312e81;
-      box-shadow: 0 22px 45px rgba(15, 23, 42, 0.45);
+      border-color: rgba(226, 232, 240, 0.9);
+      box-shadow: 0 26px 48px rgba(15, 23, 42, 0.5);
     }
 
     .dashboard-hero--demo .account-switcher {
-      background: rgba(15, 23, 42, 0.45);
-      border-color: rgba(148, 163, 184, 0.35);
+      background: rgba(15, 23, 42, 0.68);
+      border-color: rgba(148, 163, 184, 0.5);
     }
 
     .dashboard-hero--demo .account-switcher__btn.is-active {
       color: #0f172a;
+      background: linear-gradient(135deg, #c7d2fe, #eef2ff);
+      border-color: rgba(148, 163, 184, 0.7);
     }
 
     .dashboard-highlights {


### PR DESCRIPTION
## Summary
- restyle the account mode switcher and convert its controls to links so navigating between real and demo dashboards always works
- update dashboard scripts to use aria-selected semantics for the new switcher and support direct navigation fallbacks
- remove duplicated plan copy by adding an explicit billing cycle string for each plan card

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d54a42822c832b8e9dc85ddf13b7eb