### PR TITLE
Revamp demo dashboard and account switcher

### DIFF
--- a/public/demo.html
+++ b/public/demo.html
@@ -24,42 +24,55 @@
       </div>
     </header>
 
-    <main id="demoDashboard">
+    <main id="demoDashboard" class="demo-dashboard">
       <section class="dashboard-hero dashboard-hero--demo">
-        <div class="dashboard-hero__inner">
-          <div class="dashboard-hero__header">
-            <div class="dashboard-hero__titles">
+        <div class="demo-hero__glow" aria-hidden="true"></div>
+        <div class="dashboard-hero__inner demo-hero__inner">
+          <div class="demo-hero__content">
+            <div class="dashboard-hero__titles demo-hero__titles">
               <span class="dashboard-hero__badge" data-i18n="demo.badge">Preloaded</span>
               <h1 data-i18n="demo.title">Demo trading cockpit</h1>
               <p class="muted" data-i18n="demo.subtitle">Preview manual and AI strategies with simulated balances. Everything here runs in training mode.</p>
             </div>
-            <div class="dashboard-hero__actions">
+            <div class="demo-hero__actions">
               <div class="account-switcher" id="accountSwitcher" role="tablist" aria-label="Account mode">
-                <a class="account-switcher__btn" id="accountRealBtn" href="/" role="tab" data-i18n="accounts.real" aria-selected="false">Real account</a>
-                <a class="account-switcher__btn is-active" id="accountDemoBtn" href="/demo.html" role="tab" data-i18n="accounts.demo" aria-selected="true">Demo account</a>
+                <a class="account-switcher__card" id="accountRealBtn" href="/" role="tab" aria-selected="false">
+                  <span class="account-switcher__icon" aria-hidden="true">🚀</span>
+                  <span class="account-switcher__text">
+                    <span class="account-switcher__title" data-i18n="accounts.real">Real account</span>
+                    <span class="account-switcher__subtitle" data-i18n="accountSwitch.realSubtitle">Live execution with your capital</span>
+                  </span>
+                </a>
+                <a class="account-switcher__card is-active" id="accountDemoBtn" href="/demo.html" role="tab" aria-selected="true">
+                  <span class="account-switcher__icon" aria-hidden="true">🎯</span>
+                  <span class="account-switcher__text">
+                    <span class="account-switcher__title" data-i18n="accounts.demo">Demo account</span>
+                    <span class="account-switcher__subtitle" data-i18n="accountSwitch.demoSubtitle">Practice safely with virtual balance</span>
+                  </span>
+                </a>
               </div>
             </div>
           </div>
-          <div class="dashboard-highlights">
-            <article class="highlight-card">
-              <span class="highlight-label" data-i18n="demo.highlight.manualLabel">Manual strategies</span>
-              <strong class="highlight-value" id="demoManualHighlight">0</strong>
-              <span class="highlight-meta" id="demoManualMeta"></span>
+          <div class="demo-stat-grid">
+            <article class="demo-stat-card">
+              <span class="demo-stat-card__label" data-i18n="demo.highlight.manualLabel">Manual strategies</span>
+              <strong class="demo-stat-card__value" id="demoManualHighlight">0</strong>
+              <span class="demo-stat-card__meta" id="demoManualMeta"></span>
             </article>
-            <article class="highlight-card">
-              <span class="highlight-label" data-i18n="demo.highlight.aiLabel">AI strategies</span>
-              <strong class="highlight-value" id="demoAiHighlight">0</strong>
-              <span class="highlight-meta" id="demoAiMeta"></span>
+            <article class="demo-stat-card">
+              <span class="demo-stat-card__label" data-i18n="demo.highlight.aiLabel">AI strategies</span>
+              <strong class="demo-stat-card__value" id="demoAiHighlight">0</strong>
+              <span class="demo-stat-card__meta" id="demoAiMeta"></span>
             </article>
-            <article class="highlight-card">
-              <span class="highlight-label" data-i18n="demo.highlight.ordersLabel">Open orders</span>
-              <strong class="highlight-value" id="demoOrdersHighlight">0</strong>
-              <span class="highlight-meta" id="demoOrdersMeta"></span>
+            <article class="demo-stat-card">
+              <span class="demo-stat-card__label" data-i18n="demo.highlight.ordersLabel">Open orders</span>
+              <strong class="demo-stat-card__value" id="demoOrdersHighlight">0</strong>
+              <span class="demo-stat-card__meta" id="demoOrdersMeta"></span>
             </article>
-            <article class="highlight-card">
-              <span class="highlight-label" data-i18n="demo.highlight.tradesLabel">Completed trades</span>
-              <strong class="highlight-value" id="demoTradesHighlight">0</strong>
-              <span class="highlight-meta" id="demoTradesMeta"></span>
+            <article class="demo-stat-card">
+              <span class="demo-stat-card__label" data-i18n="demo.highlight.tradesLabel">Completed trades</span>
+              <strong class="demo-stat-card__value" id="demoTradesHighlight">0</strong>
+              <span class="demo-stat-card__meta" id="demoTradesMeta"></span>
             </article>
           </div>
         </div>
@@ -67,191 +80,211 @@
 
       <div id="demoStatus" class="status"></div>
 
-      <article class="card demo-intro">
-        <h2 data-i18n="demo.infoTitle">What is demo mode?</h2>
-        <p data-i18n="demo.infoBody">Use the demo workspace to explore how MY1 behaves without connecting your exchange.</p>
-        <ul class="demo-intro__list">
-          <li data-i18n="demo.infoPoint1">No subscription is required — demo mode is unlocked for every user.</li>
-          <li data-i18n="demo.infoPoint2">Binance keys are not needed; the simulator uses built-in market data.</li>
-          <li data-i18n="demo.infoPoint3">Future updates will let you practice managing rules before going live.</li>
-        </ul>
-      </article>
-
-      <section class="dashboard-grid demo-grid">
-        <article class="card demo-card" id="manualDemoCard">
-          <div class="demo-card__header">
-            <span class="pill" data-i18n="demo.badge">Preloaded</span>
-            <h2 data-i18n="demo.manualTitle">Manual rules (demo)</h2>
-          </div>
-          <p data-i18n="demo.manualSubtitle">Test dip-buying and take-profit ideas with simulated capital.</p>
-
-          <form id="manualDemoForm">
-            <div class="form-row">
-              <label>
-                <span data-i18n="demo.manual.assetId">Asset ID (CoinGecko)</span>
-                <input id="manualAssetId" type="text" placeholder="bitcoin" data-i18n-placeholder="demo.manual.assetIdPlaceholder" required>
-              </label>
-              <label>
-                <span data-i18n="demo.manual.assetSymbol">Symbol</span>
-                <input id="manualAssetSymbol" type="text" placeholder="BTC" data-i18n-placeholder="demo.manual.assetSymbolPlaceholder" required>
-              </label>
-              <label>
-                <span data-i18n="demo.manual.entryPrice">Entry price (USD)</span>
-                <input id="manualEntryPrice" type="number" min="0" step="0.0000001" placeholder="60000" data-i18n-placeholder="demo.manual.entryPlaceholder" required>
-              </label>
+      <section class="demo-overview">
+        <div class="demo-overview__grid">
+          <article class="card demo-overview__card">
+            <h2 data-i18n="demo.infoTitle">What is demo mode?</h2>
+            <p data-i18n="demo.infoBody">Use the demo workspace to explore how MY1 behaves without connecting your exchange.</p>
+            <div class="demo-overview__points">
+              <div class="demo-point" data-i18n="demo.infoPoint1">No subscription is required — demo mode is unlocked for every user.</div>
+              <div class="demo-point" data-i18n="demo.infoPoint2">Binance keys are not needed; the simulator uses built-in market data.</div>
+              <div class="demo-point" data-i18n="demo.infoPoint3">Future updates will let you practice managing rules before going live.</div>
             </div>
-            <div class="form-row">
-              <label>
-                <span data-i18n="demo.manual.takeProfit">Take profit %</span>
-                <input id="manualTakeProfit" type="number" min="0" step="0.01" placeholder="2" data-i18n-placeholder="demo.manual.takeProfitPlaceholder" required>
-              </label>
-              <label>
-                <span data-i18n="demo.manual.stopLoss">Stop loss %</span>
-                <input id="manualStopLoss" type="number" min="0" step="0.01" placeholder="1" data-i18n-placeholder="demo.manual.stopLossPlaceholder" required>
-              </label>
-              <label>
-                <span data-i18n="demo.manual.budget">Budget (USD)</span>
-                <input id="manualBudget" type="number" min="0" step="0.01" placeholder="100" data-i18n-placeholder="demo.manual.budgetPlaceholder" required>
-              </label>
+          </article>
+          <article class="card demo-overview__card demo-overview__card--accent">
+            <h2 data-i18n="demo.manualSubtitle">Test dip-buying and take-profit ideas with simulated capital.</h2>
+            <p data-i18n="demo.aiSubtitle">Preview AI-generated strategies in a safe sandbox.</p>
+            <div class="demo-overview__badges">
+              <span class="demo-overview__badge" data-i18n="demo.highlight.manualEmpty">Create your first demo rule</span>
+              <span class="demo-overview__badge" data-i18n="demo.highlight.aiEmpty">No AI rules yet</span>
             </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="demo-workspace">
+        <div class="demo-workspace__grid">
+          <article class="card demo-card" id="manualDemoCard">
+            <div class="demo-card__header">
+              <span class="pill" data-i18n="demo.badge">Preloaded</span>
+              <h2 data-i18n="demo.manualTitle">Manual rules (demo)</h2>
+            </div>
+            <p data-i18n="demo.manualSubtitle">Test dip-buying and take-profit ideas with simulated capital.</p>
+
+            <form id="manualDemoForm">
+              <div class="form-row">
+                <label>
+                  <span data-i18n="demo.manual.assetId">Asset ID (CoinGecko)</span>
+                  <input id="manualAssetId" type="text" placeholder="bitcoin" data-i18n-placeholder="demo.manual.assetIdPlaceholder" required>
+                </label>
+                <label>
+                  <span data-i18n="demo.manual.assetSymbol">Symbol</span>
+                  <input id="manualAssetSymbol" type="text" placeholder="BTC" data-i18n-placeholder="demo.manual.assetSymbolPlaceholder" required>
+                </label>
+                <label>
+                  <span data-i18n="demo.manual.entryPrice">Entry price (USD)</span>
+                  <input id="manualEntryPrice" type="number" min="0" step="0.0000001" placeholder="60000" data-i18n-placeholder="demo.manual.entryPlaceholder" required>
+                </label>
+              </div>
+              <div class="form-row">
+                <label>
+                  <span data-i18n="demo.manual.takeProfit">Take profit %</span>
+                  <input id="manualTakeProfit" type="number" min="0" step="0.01" placeholder="2" data-i18n-placeholder="demo.manual.takeProfitPlaceholder" required>
+                </label>
+                <label>
+                  <span data-i18n="demo.manual.stopLoss">Stop loss %</span>
+                  <input id="manualStopLoss" type="number" min="0" step="0.01" placeholder="1" data-i18n-placeholder="demo.manual.stopLossPlaceholder" required>
+                </label>
+                <label>
+                  <span data-i18n="demo.manual.budget">Budget (USD)</span>
+                  <input id="manualBudget" type="number" min="0" step="0.01" placeholder="100" data-i18n-placeholder="demo.manual.budgetPlaceholder" required>
+                </label>
+              </div>
+              <div class="actions">
+                <button id="manualDemoSubmit" type="submit" class="btn" data-i18n="demo.manual.create">Create demo rule</button>
+                <button id="manualDemoRefresh" type="button" class="btn ghost" data-i18n="demo.actions.refresh">Refresh</button>
+              </div>
+            </form>
+
+            <div class="table-wrapper">
+              <table id="manualDemoTable">
+                <thead>
+                  <tr>
+                    <th data-i18n="demo.table.asset">Asset</th>
+                    <th data-i18n="demo.table.entry">Entry</th>
+                    <th data-i18n="demo.table.targets">Targets</th>
+                    <th data-i18n="demo.table.budget">Budget</th>
+                    <th data-i18n="demo.table.position">Position</th>
+                    <th data-i18n="demo.table.actions">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr class="empty">
+                    <td colspan="6" data-i18n="demo.table.empty">No demo rules yet.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </article>
+
+          <article class="card demo-card" id="aiDemoCard">
+            <div class="demo-card__header">
+              <span class="pill" data-i18n="demo.badge">Preloaded</span>
+              <h2 data-i18n="demo.aiTitle">AI rules (demo)</h2>
+            </div>
+            <p data-i18n="demo.aiSubtitle">Preview AI-generated strategies in a safe sandbox.</p>
+
+            <form id="aiDemoForm">
+              <div class="form-row">
+                <label>
+                  <span data-i18n="demo.ai.budget">Budget (USD)</span>
+                  <input id="aiDemoBudget" type="number" min="0" step="0.01" placeholder="150" data-i18n-placeholder="demo.ai.budgetPlaceholder" required>
+                </label>
+                <label>
+                  <span data-i18n="demo.ai.locale">Language</span>
+                  <select id="aiDemoLocale">
+                    <option value="en" data-i18n-option="demo.ai.localeEnglish">English</option>
+                    <option value="ar" data-i18n-option="demo.ai.localeArabic">العربية</option>
+                  </select>
+                </label>
+                <label>
+                  <span data-i18n="demo.ai.model">Model</span>
+                  <input id="aiDemoModel" type="text" placeholder="gpt-4o-mini" data-i18n-placeholder="demo.ai.modelPlaceholder">
+                </label>
+              </div>
+              <div class="actions">
+                <button id="aiDemoSubmit" type="submit" class="btn" data-i18n="demo.ai.generate">Generate with AI</button>
+                <button id="aiDemoRefresh" type="button" class="btn ghost" data-i18n="demo.actions.refresh">Refresh</button>
+              </div>
+            </form>
+
+            <div class="table-wrapper">
+              <table id="aiDemoTable">
+                <thead>
+                  <tr>
+                    <th data-i18n="demo.table.asset">Asset</th>
+                    <th data-i18n="demo.table.entry">Entry</th>
+                    <th data-i18n="demo.table.targets">Targets</th>
+                    <th data-i18n="demo.table.budget">Budget</th>
+                    <th data-i18n="demo.table.summary">Summary</th>
+                    <th data-i18n="demo.table.actions">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr class="empty">
+                    <td colspan="6" data-i18n="demo.table.empty">No demo rules yet.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="demo-history">
+        <div class="demo-history__grid">
+          <article class="card demo-card" id="ordersDemoCard">
+            <div class="demo-card__header">
+              <span class="pill" data-i18n="demo.badge">Preloaded</span>
+              <h2 data-i18n="demo.ordersTitle">Open orders (demo)</h2>
+            </div>
+            <p data-i18n="demo.ordersSubtitle">Track how demo orders would execute without risking funds.</p>
             <div class="actions">
-              <button id="manualDemoSubmit" type="submit" class="btn" data-i18n="demo.manual.create">Create demo rule</button>
-              <button id="manualDemoRefresh" type="button" class="btn ghost" data-i18n="demo.actions.refresh">Refresh</button>
+              <button id="ordersDemoRefresh" type="button" class="btn ghost" data-i18n="demo.actions.refresh">Refresh</button>
             </div>
-          </form>
 
-          <div class="table-wrapper">
-            <table id="manualDemoTable">
-              <thead>
-                <tr>
-                  <th data-i18n="demo.table.asset">Asset</th>
-                  <th data-i18n="demo.table.entry">Entry</th>
-                  <th data-i18n="demo.table.targets">Targets</th>
-                  <th data-i18n="demo.table.budget">Budget</th>
-                  <th data-i18n="demo.table.position">Position</th>
-                  <th data-i18n="demo.table.actions">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="empty">
-                  <td colspan="6" data-i18n="demo.table.empty">No demo rules yet.</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </article>
-
-        <article class="card demo-card" id="aiDemoCard">
-          <div class="demo-card__header">
-            <span class="pill" data-i18n="demo.badge">Preloaded</span>
-            <h2 data-i18n="demo.aiTitle">AI rules (demo)</h2>
-          </div>
-          <p data-i18n="demo.aiSubtitle">Preview AI-generated strategies in a safe sandbox.</p>
-
-          <form id="aiDemoForm">
-            <div class="form-row">
-              <label>
-                <span data-i18n="demo.ai.budget">Budget (USD)</span>
-                <input id="aiDemoBudget" type="number" min="0" step="0.01" placeholder="150" data-i18n-placeholder="demo.ai.budgetPlaceholder" required>
-              </label>
-              <label>
-                <span data-i18n="demo.ai.locale">Language</span>
-                <select id="aiDemoLocale">
-                  <option value="en" data-i18n-option="demo.ai.localeEnglish">English</option>
-                  <option value="ar" data-i18n-option="demo.ai.localeArabic">العربية</option>
-                </select>
-              </label>
-              <label>
-                <span data-i18n="demo.ai.model">Model</span>
-                <input id="aiDemoModel" type="text" placeholder="gpt-4o-mini" data-i18n-placeholder="demo.ai.modelPlaceholder">
-              </label>
+            <div class="table-wrapper">
+              <table id="ordersDemoTable">
+                <thead>
+                  <tr>
+                    <th data-i18n="demo.table.asset">Asset</th>
+                    <th data-i18n="demo.table.side">Side</th>
+                    <th data-i18n="demo.table.price">Price</th>
+                    <th data-i18n="demo.table.quantity">Quantity</th>
+                    <th data-i18n="demo.table.value">Value</th>
+                    <th data-i18n="demo.table.status">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr class="empty">
+                    <td colspan="6" data-i18n="demo.table.ordersEmpty">No demo orders yet.</td>
+                  </tr>
+                </tbody>
+              </table>
             </div>
+          </article>
+
+          <article class="card demo-card" id="completedDemoCard">
+            <div class="demo-card__header">
+              <span class="pill" data-i18n="demo.badge">Preloaded</span>
+              <h2 data-i18n="demo.completedTitle">Completed trades (demo)</h2>
+            </div>
+            <p data-i18n="demo.completedSubtitle">Review the outcome of simulated trades once they close.</p>
             <div class="actions">
-              <button id="aiDemoSubmit" type="submit" class="btn" data-i18n="demo.ai.generate">Generate with AI</button>
-              <button id="aiDemoRefresh" type="button" class="btn ghost" data-i18n="demo.actions.refresh">Refresh</button>
+              <button id="completedDemoRefresh" type="button" class="btn ghost" data-i18n="demo.actions.refresh">Refresh</button>
             </div>
-          </form>
 
-          <div class="table-wrapper">
-            <table id="aiDemoTable">
-              <thead>
-                <tr>
-                  <th data-i18n="demo.table.asset">Asset</th>
-                  <th data-i18n="demo.table.entry">Entry</th>
-                  <th data-i18n="demo.table.targets">Targets</th>
-                  <th data-i18n="demo.table.budget">Budget</th>
-                  <th data-i18n="demo.table.summary">Summary</th>
-                  <th data-i18n="demo.table.actions">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="empty">
-                  <td colspan="6" data-i18n="demo.table.empty">No demo rules yet.</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </article>
-
-        <article class="card demo-card" id="ordersDemoCard">
-          <div class="demo-card__header">
-            <span class="pill" data-i18n="demo.badge">Preloaded</span>
-            <h2 data-i18n="demo.ordersTitle">Open orders (demo)</h2>
-          </div>
-          <p data-i18n="demo.ordersSubtitle">Track how demo orders would execute without risking funds.</p>
-          <div class="actions">
-            <button id="ordersDemoRefresh" type="button" class="btn ghost" data-i18n="demo.actions.refresh">Refresh</button>
-          </div>
-          <div class="table-wrapper">
-            <table id="ordersDemoTable">
-              <thead>
-                <tr>
-                  <th data-i18n="demo.table.asset">Asset</th>
-                  <th data-i18n="demo.table.side">Side</th>
-                  <th data-i18n="demo.table.price">Price</th>
-                  <th data-i18n="demo.table.quantity">Quantity</th>
-                  <th data-i18n="demo.table.value">Value</th>
-                  <th data-i18n="demo.table.status">Status</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="empty">
-                  <td colspan="6" data-i18n="demo.table.ordersEmpty">No demo orders yet.</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </article>
-
-        <article class="card demo-card" id="tradesDemoCard">
-          <div class="demo-card__header">
-            <span class="pill" data-i18n="demo.badge">Preloaded</span>
-            <h2 data-i18n="demo.completedTitle">Completed trades (demo)</h2>
-          </div>
-          <p data-i18n="demo.completedSubtitle">Review the outcome of simulated trades once they close.</p>
-          <div class="actions">
-            <button id="tradesDemoRefresh" type="button" class="btn ghost" data-i18n="demo.actions.refresh">Refresh</button>
-          </div>
-          <div class="table-wrapper">
-            <table id="tradesDemoTable">
-              <thead>
-                <tr>
-                  <th data-i18n="demo.table.asset">Asset</th>
-                  <th data-i18n="demo.table.entry">Entry</th>
-                  <th data-i18n="demo.table.exit">Exit</th>
-                  <th data-i18n="demo.table.quantity">Quantity</th>
-                  <th data-i18n="demo.table.profit">Profit</th>
-                  <th data-i18n="demo.table.opened">Opened</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="empty">
-                  <td colspan="6" data-i18n="demo.table.tradesEmpty">No completed demo trades yet.</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </article>
+            <div class="table-wrapper">
+              <table id="completedDemoTable">
+                <thead>
+                  <tr>
+                    <th data-i18n="demo.table.asset">Asset</th>
+                    <th data-i18n="demo.table.entry">Entry</th>
+                    <th data-i18n="demo.table.exit">Exit</th>
+                    <th data-i18n="demo.table.profit">Profit</th>
+                    <th data-i18n="demo.table.opened">Opened</th>
+                    <th data-i18n="demo.table.status">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr class="empty">
+                    <td colspan="6" data-i18n="demo.table.tradesEmpty">No completed demo trades yet.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </article>
+        </div>
       </section>
     </main>
   </div>

--- a/public/index.html
+++ b/public/index.html
@@ -164,10 +164,22 @@
               <p class="muted" data-i18n="dashboard.subtitle">Manage AI ideas, monitor open orders, and keep your Binance link under supervision.</p>
             </div>
             <div class="dashboard-hero__actions">
-              <div class="account-switcher" id="accountSwitcher" role="tablist" aria-label="Account mode">
-                <a class="account-switcher__btn is-active" id="accountRealBtn" href="/" role="tab" data-i18n="accounts.real" aria-selected="true">Real account</a>
-                <a class="account-switcher__btn" id="accountDemoBtn" href="/demo.html" role="tab" data-i18n="accounts.demo" aria-selected="false">Demo account</a>
-              </div>
+            <div class="account-switcher" id="accountSwitcher" role="tablist" aria-label="Account mode">
+              <a class="account-switcher__card is-active" id="accountRealBtn" href="/" role="tab" aria-selected="true">
+                <span class="account-switcher__icon" aria-hidden="true">🚀</span>
+                <span class="account-switcher__text">
+                  <span class="account-switcher__title" data-i18n="accounts.real">Real account</span>
+                  <span class="account-switcher__subtitle" data-i18n="accountSwitch.realSubtitle">Live execution with your capital</span>
+                </span>
+              </a>
+              <a class="account-switcher__card" id="accountDemoBtn" href="/demo.html" role="tab" aria-selected="false">
+                <span class="account-switcher__icon" aria-hidden="true">🎯</span>
+                <span class="account-switcher__text">
+                  <span class="account-switcher__title" data-i18n="accounts.demo">Demo account</span>
+                  <span class="account-switcher__subtitle" data-i18n="accountSwitch.demoSubtitle">Practice safely with virtual balance</span>
+                </span>
+              </a>
+            </div>
               <div class="user-meta">
                 <span class="pill" id="welcomeName" data-i18n="dashboard.welcome">Welcome</span>
                 <button class="btn ghost" id="logoutBtn" type="button" data-i18n="dashboard.logout">Sign out</button>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -85,6 +85,10 @@
           real: "Real account",
           demo: "Demo account"
         },
+        accountSwitch: {
+          realSubtitle: "Live execution with your capital",
+          demoSubtitle: "Practice safely with virtual balance"
+        },
         api: {
           title: "Connect Binance keys",
           description: "Add your spot API credentials to activate the engine. Keys remain encrypted and you can revoke them any time.",
@@ -390,6 +394,10 @@
           real: "الحساب الحقيقي",
           demo: "الحساب التجريبي"
         },
+        accountSwitch: {
+          realSubtitle: "تنفيذ حقيقي بأموالك",
+          demoSubtitle: "تدرّب بأرصدة افتراضية بأمان"
+        },
         api: {
           title: "ربط مفاتيح Binance",
           description: "أضف مفاتيح السبوت الخاصة بك لتفعيل المحرك. تبقى المفاتيح مشفرة ويمكنك إزالتها في أي وقت.",
@@ -689,6 +697,7 @@
     const refreshOrdersBtn = document.getElementById('refreshOrders');
     const refreshCompletedBtn = document.getElementById('refreshCompletedTrades');
     const languageToggle = document.getElementById('languageToggle');
+    const pricingSection = document.getElementById('pricingSection');
     const pricingGrid = document.getElementById('pricingGrid');
     const dashboardPlansGrid = document.getElementById('dashboardPlans');
     const subscriptionStatus = document.getElementById('subscriptionStatus');
@@ -1731,6 +1740,16 @@
     }
 
     function renderPricingCards() {
+      if (!pricingGrid) return;
+      const dashboardVisible = dashboard && !dashboard.classList.contains('hidden');
+      const shouldShow = !state.token && !dashboardVisible;
+      if (pricingSection) {
+        pricingSection.classList.toggle('hidden', !shouldShow);
+      }
+      if (!shouldShow) {
+        pricingGrid.innerHTML = '';
+        return;
+      }
       renderPlanGrid(pricingGrid, 'landing');
     }
 

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -11,6 +11,10 @@
         real: 'Real account',
         demo: 'Demo account'
       },
+      accountSwitch: {
+        realSubtitle: 'Live execution with your capital',
+        demoSubtitle: 'Practice safely with virtual balance'
+      },
       demo: {
         title: 'Demo trading cockpit',
         subtitle: 'Preview manual and AI strategies with simulated balances. Everything here runs in training mode.',
@@ -100,6 +104,7 @@
           created: 'Demo rule created successfully.',
           generated: 'AI demo rule generated successfully.',
           deleted: 'Demo rule removed.',
+          completed: 'Completed',
           error: 'Something went wrong, please try again.'
         },
         buttons: {
@@ -117,6 +122,10 @@
       accounts: {
         real: 'الحساب الحقيقي',
         demo: 'الحساب التجريبي'
+      },
+      accountSwitch: {
+        realSubtitle: 'تنفيذ حقيقي بأموالك',
+        demoSubtitle: 'تدرّب بأرصدة افتراضية بأمان'
       },
       demo: {
         title: 'قمرة التداول التجريبية',
@@ -207,6 +216,7 @@
           created: 'تم إنشاء القاعدة التجريبية بنجاح.',
           generated: 'تم توليد قاعدة الذكاء الاصطناعي التجريبية بنجاح.',
           deleted: 'تم حذف القاعدة التجريبية.',
+          completed: 'مكتملة',
           error: 'حدث خطأ ما، حاول مرة أخرى.'
         },
         buttons: {
@@ -265,8 +275,8 @@
 
   const ordersRefreshBtn = document.getElementById('ordersDemoRefresh');
   const ordersTableBody = document.querySelector('#ordersDemoTable tbody');
-  const tradesRefreshBtn = document.getElementById('tradesDemoRefresh');
-  const tradesTableBody = document.querySelector('#tradesDemoTable tbody');
+  const completedRefreshBtn = document.getElementById('completedDemoRefresh');
+  const completedTableBody = document.querySelector('#completedDemoTable tbody');
   let statusTimer = null;
 
   function resolveTranslation(lang, key) {
@@ -353,7 +363,7 @@
   }
 
   function disableForms(disabled) {
-    const forms = [manualSubmitBtn, manualRefreshBtn, aiSubmitBtn, aiRefreshBtn, ordersRefreshBtn, tradesRefreshBtn];
+    const forms = [manualSubmitBtn, manualRefreshBtn, aiSubmitBtn, aiRefreshBtn, ordersRefreshBtn, completedRefreshBtn];
     forms.forEach(btn => {
       if (btn) {
         btn.disabled = disabled;
@@ -600,8 +610,8 @@
   }
 
   function renderTrades(trades) {
-    if (!tradesTableBody) return;
-    tradesTableBody.innerHTML = '';
+    if (!completedTableBody) return;
+    completedTableBody.innerHTML = '';
     if (!trades.length) {
       const row = document.createElement('tr');
       row.className = 'empty';
@@ -609,25 +619,25 @@
       cell.colSpan = 6;
       cell.textContent = translate('demo.table.tradesEmpty');
       row.appendChild(cell);
-      tradesTableBody.appendChild(row);
+      completedTableBody.appendChild(row);
       return;
     }
     trades.forEach(trade => {
       const row = document.createElement('tr');
       const entryPrice = formatNumber(trade.entryPrice, { maximumFractionDigits: 4 });
       const exitPrice = formatNumber(trade.exitPrice, { maximumFractionDigits: 4 });
-      const quantity = formatNumber(trade.quantity, { maximumFractionDigits: 4 });
       const profitPct = formatNumber(trade.profitPct, { maximumFractionDigits: 2 });
       const createdAt = formatTimestamp(trade.createdAt);
+      const statusLabel = trade.status ? String(trade.status) : translate('demo.status.completed');
       row.innerHTML = `
         <td>${escapeHtml(trade.assetSymbol)}</td>
         <td>${escapeHtml(entryPrice)}</td>
         <td>${escapeHtml(exitPrice)}</td>
-        <td>${escapeHtml(quantity)}</td>
         <td>${escapeHtml(formatCurrency(trade.profitUSD))} (${escapeHtml(profitPct)}%)</td>
         <td>${escapeHtml(createdAt)}</td>
+        <td>${escapeHtml(statusLabel)}</td>
       `;
-      tradesTableBody.appendChild(row);
+      completedTableBody.appendChild(row);
     });
 
     updateHighlights();
@@ -840,8 +850,8 @@
         loadOrders();
       });
     }
-    if (tradesRefreshBtn) {
-      tradesRefreshBtn.addEventListener('click', () => {
+    if (completedRefreshBtn) {
+      completedRefreshBtn.addEventListener('click', () => {
         loadTrades();
       });
     }

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -719,101 +719,102 @@
     }
 
     .account-switcher {
-      display: inline-flex;
-      align-items: center;
-      gap: 12px;
-      padding: 10px;
-      border-radius: 999px;
-      background: linear-gradient(135deg, rgba(99, 102, 241, 0.16), rgba(59, 130, 246, 0.12));
-      border: 1px solid rgba(99, 102, 241, 0.28);
-      box-shadow: 0 22px 48px rgba(79, 70, 229, 0.18);
-      flex-wrap: wrap;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 16px;
+      padding: 18px;
+      border-radius: 24px;
+      background: linear-gradient(135deg, rgba(79, 70, 229, 0.22), rgba(14, 165, 233, 0.18));
+      border: 1px solid rgba(148, 163, 184, 0.4);
+      box-shadow: 0 22px 48px rgba(15, 23, 42, 0.32);
     }
 
-    .account-switcher__btn {
+    .account-switcher__card {
+      position: relative;
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      padding: 22px 24px;
+      border-radius: 20px;
+      text-decoration: none;
+      background: linear-gradient(135deg, rgba(15, 23, 42, 0.72), rgba(30, 41, 59, 0.68));
+      border: 1px solid rgba(148, 163, 184, 0.45);
+      color: rgba(226, 232, 240, 0.92);
+      box-shadow: 0 18px 36px rgba(15, 23, 42, 0.45);
+      transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease, border-color 0.25s ease;
+    }
+
+    .account-switcher__card:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 24px 46px rgba(15, 23, 42, 0.55);
+      border-color: rgba(165, 180, 252, 0.55);
+    }
+
+    .account-switcher__card.is-active {
+      background: linear-gradient(135deg, #f8fafc, #e2e8f0);
+      color: #1f1d4d;
+      border-color: rgba(226, 232, 240, 0.9);
+      box-shadow: 0 28px 56px rgba(15, 23, 42, 0.55);
+    }
+
+    .account-switcher__card:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.4), 0 22px 48px rgba(79, 70, 229, 0.38);
+    }
+
+    .account-switcher__icon {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      gap: 6px;
-      padding: 14px 32px;
-      border-radius: 999px;
-      font-size: 1rem;
+      width: 52px;
+      height: 52px;
+      border-radius: 16px;
+      background: rgba(148, 163, 184, 0.2);
+      font-size: 1.6rem;
+      flex-shrink: 0;
+    }
+
+    .account-switcher__card.is-active .account-switcher__icon {
+      background: rgba(79, 70, 229, 0.18);
+      color: #312e81;
+    }
+
+    .account-switcher__text {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .account-switcher__title {
+      font-size: 1.1rem;
       font-weight: 700;
       letter-spacing: 0.01em;
-      cursor: pointer;
-      text-decoration: none;
-      color: var(--accent);
-      background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(226, 232, 240, 0.88));
-      border: 1px solid rgba(99, 102, 241, 0.4);
-      box-shadow: 0 14px 26px rgba(99, 102, 241, 0.2);
-      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-      min-width: 0;
     }
 
-    .account-switcher__btn:visited {
+    .account-switcher__subtitle {
+      font-size: 0.95rem;
       color: inherit;
+      opacity: 0.78;
+      line-height: 1.35;
     }
 
-    .account-switcher__btn:hover {
-      transform: translateY(-2px);
-      background: linear-gradient(135deg, rgba(224, 231, 255, 1), rgba(199, 210, 254, 0.95));
-      border-color: rgba(79, 70, 229, 0.5);
-      box-shadow: 0 18px 32px rgba(79, 70, 229, 0.28);
-      color: var(--accent-dark);
-    }
-
-    .account-switcher__btn.is-active {
-      background: linear-gradient(135deg, #4f46e5, #6366f1);
-      border-color: rgba(79, 70, 229, 0.85);
-      color: #fff;
-      box-shadow: 0 24px 38px rgba(79, 70, 229, 0.45);
-      transform: translateY(-1px);
-    }
-
-    .account-switcher__btn:focus-visible {
-      outline: none;
-      box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.35), 0 14px 28px rgba(99, 102, 241, 0.2);
-    }
-
-    .account-switcher__btn:active {
-      transform: translateY(0);
+    .account-switcher__card.is-active .account-switcher__subtitle {
+      opacity: 0.85;
+      color: rgba(30, 41, 59, 0.72);
     }
 
     .dashboard-hero .account-switcher {
-      background: rgba(15, 23, 42, 0.52);
-      border-color: rgba(148, 163, 184, 0.45);
-      box-shadow: 0 26px 52px rgba(15, 23, 42, 0.45);
-    }
-
-    .dashboard-hero .account-switcher__btn {
-      color: rgba(226, 232, 240, 0.9);
-      background: linear-gradient(135deg, rgba(30, 41, 59, 0.72), rgba(51, 65, 85, 0.65));
-      border-color: rgba(148, 163, 184, 0.45);
-      box-shadow: 0 16px 32px rgba(15, 23, 42, 0.45);
-    }
-
-    .dashboard-hero .account-switcher__btn:hover {
-      color: #fff;
-      background: linear-gradient(135deg, rgba(59, 130, 246, 0.45), rgba(99, 102, 241, 0.42));
-      border-color: rgba(148, 163, 184, 0.6);
-    }
-
-    .dashboard-hero .account-switcher__btn.is-active {
-      background: linear-gradient(135deg, #f8fafc, #e2e8f0);
-      color: #312e81;
-      border-color: rgba(226, 232, 240, 0.9);
-      box-shadow: 0 26px 48px rgba(15, 23, 42, 0.5);
+      background: rgba(15, 23, 42, 0.58);
+      border-color: rgba(148, 163, 184, 0.42);
+      box-shadow: 0 28px 56px rgba(15, 23, 42, 0.45);
     }
 
     .dashboard-hero--demo .account-switcher {
-      background: rgba(15, 23, 42, 0.68);
-      border-color: rgba(148, 163, 184, 0.5);
+      background: rgba(15, 23, 42, 0.72);
     }
 
-    .dashboard-hero--demo .account-switcher__btn.is-active {
-      color: #0f172a;
-      background: linear-gradient(135deg, #c7d2fe, #eef2ff);
-      border-color: rgba(148, 163, 184, 0.7);
+    .dashboard-hero--demo .account-switcher__card.is-active {
+      color: #1d1a4b;
     }
 
     .dashboard-highlights {
@@ -896,14 +897,14 @@
 
       .dashboard-hero .account-switcher {
         width: 100%;
-        justify-content: space-between;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
       }
     }
 
     @media (max-width: 640px) {
-      .dashboard-hero .account-switcher__btn {
-        flex: 1 1 140px;
-        text-align: center;
+      .account-switcher__card {
+        flex-direction: column;
+        align-items: flex-start;
       }
 
       .dashboard-highlights {
@@ -916,8 +917,12 @@
         grid-template-columns: 1fr;
       }
 
-      .dashboard-hero .account-switcher__btn {
-        flex: 1 1 100%;
+      .account-switcher {
+        padding: 16px;
+      }
+
+      .account-switcher__card {
+        padding: 20px;
       }
     }
 
@@ -963,6 +968,183 @@
       flex-shrink: 0;
     }
 
+    .demo-dashboard {
+      display: flex;
+      flex-direction: column;
+      gap: clamp(32px, 6vw, 48px);
+      padding: clamp(32px, 6vw, 60px) clamp(20px, 8vw, 84px) 80px;
+    }
+
+    .dashboard-hero--demo {
+      position: relative;
+      overflow: hidden;
+      border-radius: 32px;
+      padding: clamp(32px, 6vw, 60px);
+      background: linear-gradient(135deg, rgba(15, 23, 42, 0.94), rgba(37, 99, 235, 0.72));
+      box-shadow: 0 45px 120px rgba(15, 23, 42, 0.4);
+    }
+
+    .demo-hero__glow {
+      position: absolute;
+      inset: -25% -35% -30% -20%;
+      background:
+        radial-gradient(circle at 18% 18%, rgba(99, 102, 241, 0.45), transparent 60%),
+        radial-gradient(circle at 82% 36%, rgba(56, 189, 248, 0.34), transparent 58%),
+        radial-gradient(circle at 50% 100%, rgba(76, 29, 149, 0.28), transparent 68%);
+      opacity: 0.85;
+      pointer-events: none;
+    }
+
+    .demo-hero__inner {
+      position: relative;
+      z-index: 1;
+      display: grid;
+      gap: clamp(28px, 5vw, 40px);
+    }
+
+    @media (min-width: 960px) {
+      .demo-hero__inner {
+        grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+        align-items: end;
+      }
+    }
+
+    .demo-hero__content {
+      display: flex;
+      flex-direction: column;
+      gap: clamp(18px, 4vw, 28px);
+      color: #e2e8f0;
+    }
+
+    .demo-hero__actions {
+      max-width: 520px;
+    }
+
+    .demo-stat-grid {
+      display: grid;
+      gap: clamp(16px, 4vw, 20px);
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    }
+
+    .demo-stat-card {
+      position: relative;
+      padding: 22px;
+      border-radius: 20px;
+      border: 1px solid rgba(226, 232, 240, 0.25);
+      background: linear-gradient(160deg, rgba(15, 23, 42, 0.55), rgba(30, 64, 175, 0.35));
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+      display: grid;
+      gap: 8px;
+      color: #f8fafc;
+    }
+
+    .demo-stat-card::after {
+      content: "";
+      position: absolute;
+      inset: -40% -10% 60% 10%;
+      background: radial-gradient(circle at 20% 25%, rgba(99, 102, 241, 0.32), transparent 65%);
+      pointer-events: none;
+      opacity: 0.7;
+    }
+
+    .demo-stat-card__label {
+      font-size: 0.9rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      opacity: 0.75;
+    }
+
+    .demo-stat-card__value {
+      font-size: 1.9rem;
+      font-weight: 700;
+    }
+
+    .demo-stat-card__meta {
+      font-size: 0.9rem;
+      opacity: 0.7;
+    }
+
+    .demo-overview {
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+    }
+
+    .demo-overview__grid {
+      display: grid;
+      gap: 24px;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      align-items: stretch;
+    }
+
+    .demo-overview__card {
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+      min-height: 100%;
+    }
+
+    .demo-overview__points {
+      display: grid;
+      gap: 14px;
+    }
+
+    .demo-point {
+      padding: 14px 16px;
+      border-radius: 16px;
+      background: rgba(226, 232, 240, 0.45);
+      color: #0f172a;
+      font-weight: 600;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+    }
+
+    .demo-overview__card--accent {
+      background: linear-gradient(150deg, rgba(59, 130, 246, 0.18), rgba(165, 180, 252, 0.12));
+      border-color: rgba(79, 70, 229, 0.28);
+    }
+
+    .demo-overview__badges {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .demo-overview__badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 16px;
+      border-radius: 999px;
+      background: rgba(79, 70, 229, 0.12);
+      color: #312e81;
+      font-weight: 600;
+      font-size: 0.9rem;
+    }
+
+    .demo-workspace {
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+    }
+
+    .demo-workspace__grid {
+      display: grid;
+      gap: 24px;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    }
+
+    .demo-history {
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+    }
+
+    .demo-history__grid {
+      display: grid;
+      gap: 24px;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    }
+
     .demo-placeholder {
       margin-top: 20px;
       padding: 26px;
@@ -974,34 +1156,31 @@
       font-weight: 500;
     }
 
-    .demo-intro {
-      margin-bottom: 32px;
+    @media (max-width: 720px) {
+      .demo-dashboard {
+        padding: 32px 24px 64px;
+      }
+
+      .demo-overview__grid,
+      .demo-workspace__grid,
+      .demo-history__grid {
+        grid-template-columns: 1fr;
+      }
     }
 
-    .demo-intro__list {
-      margin: 16px 0 0;
-      padding: 0;
-      list-style: none;
-      display: grid;
-      gap: 10px;
-    }
+    @media (max-width: 480px) {
+      .demo-dashboard {
+        padding: 28px 18px 56px;
+      }
 
-    .demo-intro__list li {
-      position: relative;
-      padding-inline-start: 22px;
-      color: var(--muted);
-      font-weight: 500;
-    }
+      .demo-overview__badge {
+        width: 100%;
+        justify-content: center;
+      }
 
-    .demo-intro__list li::before {
-      content: "";
-      position: absolute;
-      width: 8px;
-      height: 8px;
-      border-radius: 50%;
-      background: var(--accent);
-      top: 10px;
-      inset-inline-start: 0;
+      .demo-stat-card__value {
+        font-size: 1.6rem;
+      }
     }
 
     .card {


### PR DESCRIPTION
## Summary
- Restyle the account mode switcher as prominent cards with new subtitle translations
- Hide the marketing pricing grid when the dashboard is active to avoid duplicate plan cards
- Rebuild the demo dashboard layout, tables, and translations to deliver a modern hero, overview, and workspace

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d54fc0c83c832b8f69ebe5844ce133