### PR TITLE
Revamp marketing theme and enforce demo auth redirect

### DIFF
--- a/public/demo.html
+++ b/public/demo.html
@@ -6,7 +6,7 @@
   <title>MY1 Demo Trading</title>
   <link rel="stylesheet" href="/styles/main.css">
 </head>
-<body>
+<body data-login-url="/">
   <div class="site">
     <header class="site-header">
       <div class="container">

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/styles/main.css">
 
 </head>
-<body>
+<body data-login-url="/">
   <div class="site">
     <header class="site-header">
       <div class="container">

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -242,6 +242,24 @@
     }
   };
 
+  const loginDestination = (() => {
+    const explicit = document.body?.getAttribute('data-login-url');
+    if (explicit) return explicit;
+    return '/';
+  })();
+
+  function redirectToLogin() {
+    try {
+      const target = new URL(loginDestination || '/', window.location.origin);
+      const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      if (current !== `${target.pathname}${target.search}${target.hash}`) {
+        window.location.replace(target.toString());
+      }
+    } catch (err) {
+      window.location.replace(loginDestination || '/');
+    }
+  }
+
   const languageToggle = document.getElementById('languageToggle');
   const accountRealBtn = document.getElementById('accountRealBtn');
   const accountDemoBtn = document.getElementById('accountDemoBtn');
@@ -359,6 +377,7 @@
     if (state.token) return false;
     disableForms(true);
     setStatus(translate('demo.status.loginRequired'), 'error');
+    redirectToLogin();
     return true;
   }
 
@@ -418,6 +437,7 @@
         setStatus(translate('demo.status.loginRequired'), 'error');
         state.timers.forEach(timer => clearInterval(timer));
         state.timers = [];
+        redirectToLogin();
         throw new Error('AUTH_REQUIRED');
       }
       const message = typeof data?.error === 'string' ? data.error : res.statusText;

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -2086,3 +2086,340 @@
       .hero-preview-status { align-self: flex-start; }
       .section-kicker { font-size: 0.75rem; padding: 6px 12px; }
     }
+
+    /* --- Revamped experience theme overrides --- */
+    :root {
+      --bg: linear-gradient(140deg, #f5f7ff 0%, #eef6ff 45%, #f6f1ff 100%);
+      --bg-accent: radial-gradient(circle at 15% 25%, rgba(79, 70, 229, 0.18), transparent 55%),
+        radial-gradient(circle at 80% 15%, rgba(14, 165, 233, 0.18), transparent 50%),
+        radial-gradient(circle at 60% 80%, rgba(16, 185, 129, 0.16), transparent 55%);
+      --surface: rgba(255, 255, 255, 0.92);
+      --surface-strong: #ffffff;
+      --glass: rgba(15, 23, 42, 0.08);
+      --glass-border: rgba(15, 23, 42, 0.08);
+      --text: #0f172a;
+      --muted: #475569;
+      --accent: #2563eb;
+      --accent-dark: #1d4ed8;
+      --accent-soft: rgba(37, 99, 235, 0.14);
+      --success: #059669;
+      --danger: #dc2626;
+      --shadow: 0 34px 70px rgba(15, 23, 42, 0.12);
+      --footer-bg: rgba(15, 23, 42, 0.92);
+    }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+    }
+
+    body::before {
+      background: var(--bg);
+    }
+
+    body::after {
+      background: var(--bg-accent);
+      opacity: 1;
+      filter: blur(85px);
+    }
+
+    .site-header {
+      background: rgba(255, 255, 255, 0.85);
+      color: var(--text);
+      border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+      box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+    }
+
+    .site-header::after {
+      background: linear-gradient(90deg, rgba(37, 99, 235, 0.35), transparent);
+      opacity: 1;
+    }
+
+    .logo {
+      background: linear-gradient(135deg, #2563eb, #7c3aed);
+      color: #fff;
+      box-shadow: 0 16px 26px rgba(37, 99, 235, 0.2);
+    }
+
+    .tagline strong { color: var(--text); font-size: 1.05rem; }
+    .tagline span { color: var(--muted); }
+
+    .language-toggle {
+      border-color: rgba(37, 99, 235, 0.22);
+      background: rgba(37, 99, 235, 0.12);
+      color: var(--accent-dark);
+      box-shadow: 0 10px 18px rgba(37, 99, 235, 0.12);
+    }
+
+    .language-toggle:hover { background: rgba(37, 99, 235, 0.2); }
+
+    .ghost-link {
+      border-color: rgba(37, 99, 235, 0.2);
+      color: var(--accent-dark);
+      background: rgba(255, 255, 255, 0.85);
+      box-shadow: 0 12px 24px rgba(37, 99, 235, 0.12);
+    }
+
+    .ghost-link:hover {
+      background: rgba(37, 99, 235, 0.15);
+      color: var(--accent-dark);
+    }
+
+    .hero {
+      color: var(--text);
+      padding: clamp(72px, 12vw, 140px) clamp(20px, 9vw, 120px);
+    }
+
+    .hero::before {
+      background: radial-gradient(circle at 20% 20%, rgba(14, 165, 233, 0.28), transparent 60%);
+      opacity: 1;
+    }
+
+    .hero::after {
+      background: radial-gradient(circle at 75% 65%, rgba(124, 58, 237, 0.22), transparent 62%);
+      opacity: 0.8;
+    }
+
+    .hero-content {
+      border-radius: 32px;
+      padding: clamp(32px, 5vw, 48px);
+      background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.75));
+      border: 1px solid rgba(15, 23, 42, 0.08);
+      box-shadow: var(--shadow);
+      align-items: center;
+    }
+
+    .hero-copy { max-width: 580px; }
+
+    .hero-badge {
+      background: linear-gradient(90deg, rgba(37, 99, 235, 0.15), rgba(124, 58, 237, 0.15));
+      color: var(--accent-dark);
+      border: 1px solid rgba(37, 99, 235, 0.18);
+    }
+
+    .hero-actions .btn.primary {
+      background: linear-gradient(135deg, #2563eb, #7c3aed);
+      box-shadow: 0 20px 35px rgba(37, 99, 235, 0.25);
+    }
+
+    .hero-actions .btn.primary:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 24px 45px rgba(37, 99, 235, 0.25);
+    }
+
+    .hero-actions .btn.secondary {
+      border-color: rgba(37, 99, 235, 0.35);
+      color: var(--accent-dark);
+      background: rgba(37, 99, 235, 0.1);
+    }
+
+    .hero-actions .btn.secondary:hover {
+      background: rgba(37, 99, 235, 0.18);
+    }
+
+    .hero-stats {
+      background: rgba(255, 255, 255, 0.75);
+      border: 1px solid rgba(148, 163, 184, 0.16);
+      border-radius: 20px;
+      backdrop-filter: blur(14px);
+    }
+
+    .hero-stat { color: var(--text); }
+    .hero-stat .stat-label { color: var(--muted); }
+
+    .hero-visual {
+      position: relative;
+      display: grid;
+      gap: 24px;
+    }
+
+    .hero-visual-glow {
+      background: radial-gradient(circle at 60% 40%, rgba(37, 99, 235, 0.22), transparent 60%);
+      filter: blur(40px);
+    }
+
+    .hero-preview {
+      border-radius: 24px;
+      background: rgba(15, 23, 42, 0.85);
+      color: #fff;
+      border: 1px solid rgba(148, 163, 184, 0.18);
+      box-shadow: 0 30px 60px rgba(15, 23, 42, 0.28);
+    }
+
+    .hero-feature-grid {
+      background: rgba(255, 255, 255, 0.8);
+      border-radius: 24px;
+      border: 1px solid rgba(148, 163, 184, 0.18);
+      box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+    }
+
+    .feature-card {
+      background: transparent;
+      border: none;
+      box-shadow: none;
+      border-radius: 20px;
+      padding: 20px 24px;
+    }
+
+    .feature-card + .feature-card { border-top: 1px solid rgba(148, 163, 184, 0.14); }
+    .feature-card h3 { color: var(--text); }
+    .feature-card p { color: var(--muted); }
+
+    .pricing {
+      background: transparent;
+      padding-top: clamp(60px, 10vw, 100px);
+    }
+
+    .pricing-inner {
+      background: rgba(255, 255, 255, 0.86);
+      border-radius: 32px;
+      border: 1px solid rgba(148, 163, 184, 0.12);
+      box-shadow: 0 28px 60px rgba(15, 23, 42, 0.12);
+      padding: clamp(32px, 6vw, 60px);
+    }
+
+    .pricing-grid .card {
+      background: var(--surface-strong);
+      border: 1px solid rgba(148, 163, 184, 0.16);
+      box-shadow: 0 22px 45px rgba(15, 23, 42, 0.14);
+    }
+
+    .pricing-grid .card.is-featured {
+      border: 1px solid rgba(37, 99, 235, 0.45);
+      box-shadow: 0 30px 60px rgba(37, 99, 235, 0.25);
+    }
+
+    .auth-section {
+      padding: clamp(60px, 10vw, 110px) clamp(16px, 8vw, 120px);
+    }
+
+    .auth-card {
+      background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(239, 246, 255, 0.9));
+      border-radius: 32px;
+      border: 1px solid rgba(148, 163, 184, 0.12);
+      box-shadow: 0 36px 70px rgba(15, 23, 42, 0.14);
+      padding: clamp(32px, 6vw, 56px);
+      gap: clamp(32px, 5vw, 60px);
+    }
+
+    .auth-copy h2 { color: var(--text); font-size: clamp(2rem, 4vw, 2.6rem); }
+    .auth-copy p { color: var(--muted); font-size: 1.05rem; }
+
+    .auth-panel {
+      background: rgba(255, 255, 255, 0.9);
+      border: 1px solid rgba(148, 163, 184, 0.16);
+      border-radius: 24px;
+      padding: clamp(24px, 4vw, 36px);
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+    }
+
+    .auth-tabs {
+      background: rgba(37, 99, 235, 0.08);
+      border-radius: 999px;
+      padding: 6px;
+      gap: 6px;
+    }
+
+    .auth-tabs button {
+      flex: 1;
+      border-radius: 999px;
+      background: transparent;
+      color: var(--muted);
+      font-weight: 600;
+    }
+
+    .auth-tabs button.is-active {
+      background: linear-gradient(135deg, #2563eb, #7c3aed);
+      color: #fff;
+      box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+    }
+
+    .auth-panel label { color: var(--muted); font-weight: 600; }
+    .auth-panel input {
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      background: rgba(248, 250, 252, 0.9);
+      border-radius: 14px;
+      padding: 14px 16px;
+    }
+
+    .auth-panel input:focus {
+      border-color: rgba(37, 99, 235, 0.55);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+    }
+
+    .auth-panel .btn.primary {
+      width: 100%;
+      margin-top: 8px;
+      background: linear-gradient(135deg, #2563eb, #7c3aed);
+      box-shadow: 0 16px 28px rgba(37, 99, 235, 0.22);
+    }
+
+    .status.info { background: rgba(14, 165, 233, 0.12); color: #0e7490; }
+    .status.success { background: rgba(34, 197, 94, 0.12); color: #047857; }
+    .status.error { background: rgba(248, 113, 113, 0.15); color: #b91c1c; }
+
+    .dashboard-hero__inner {
+      background: rgba(255, 255, 255, 0.92);
+      border-radius: 32px;
+      border: 1px solid rgba(148, 163, 184, 0.16);
+      box-shadow: 0 32px 60px rgba(15, 23, 42, 0.15);
+      padding: clamp(28px, 5vw, 48px);
+    }
+
+    .dashboard-hero__badge {
+      background: rgba(37, 99, 235, 0.12);
+      color: var(--accent-dark);
+      border: 1px solid rgba(37, 99, 235, 0.18);
+    }
+
+    .account-switcher__card {
+      border: 1px solid rgba(148, 163, 184, 0.18);
+      background: rgba(248, 250, 252, 0.9);
+    }
+
+    .account-switcher__card.is-active {
+      border-color: rgba(37, 99, 235, 0.45);
+      box-shadow: 0 18px 40px rgba(37, 99, 235, 0.22);
+      background: linear-gradient(135deg, rgba(37, 99, 235, 0.16), rgba(124, 58, 237, 0.16));
+    }
+
+    .highlight-card {
+      background: rgba(248, 250, 252, 0.92);
+      border: 1px solid rgba(148, 163, 184, 0.16);
+      box-shadow: 0 18px 38px rgba(15, 23, 42, 0.12);
+    }
+
+    .highlight-card.is-empty {
+      border-style: dashed;
+      background: rgba(255, 255, 255, 0.75);
+    }
+
+    .card,
+    .metric-card,
+    .trade-card,
+    table {
+      background: rgba(255, 255, 255, 0.92);
+      border: 1px solid rgba(148, 163, 184, 0.16);
+      box-shadow: 0 18px 38px rgba(15, 23, 42, 0.12);
+    }
+
+    th { color: var(--muted); }
+
+    tbody tr { border-bottom: 1px solid rgba(148, 163, 184, 0.1); }
+
+    .pill.success { background: rgba(34, 197, 94, 0.12); color: #047857; }
+    .pill.danger { background: rgba(248, 113, 113, 0.12); color: #b91c1c; }
+    .pill.info { background: rgba(14, 165, 233, 0.12); color: #0369a1; }
+
+    footer.site-footer {
+      background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.92));
+      color: rgba(255, 255, 255, 0.85);
+      border-top: 1px solid rgba(255, 255, 255, 0.06);
+    }
+
+    @media (max-width: 768px) {
+      .hero-content { padding: clamp(24px, 7vw, 36px); }
+      .hero-feature-grid { grid-template-columns: 1fr; }
+      .auth-card { padding: clamp(24px, 8vw, 40px); }
+      .dashboard-hero__inner { padding: clamp(24px, 8vw, 36px); }
+    }


### PR DESCRIPTION
## Summary
- refresh the public landing and dashboard visuals with a brighter gradient theme, glass cards, and updated component styling
- add an explicit login URL hook on the HTML shell so dependent pages can redirect consistently
- redirect visitors without a token away from the demo workspace back to the login view

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d555a88900832b9b88ce783eef1281