### PR TITLE
Improve demo dashboard readability

### DIFF
--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -1026,6 +1026,23 @@
       flex-direction: column;
       gap: clamp(18px, 4vw, 28px);
       color: #e2e8f0;
+      background: linear-gradient(145deg, rgba(15, 23, 42, 0.78), rgba(30, 41, 59, 0.58));
+      border: 1px solid rgba(148, 163, 184, 0.45);
+      border-radius: 28px;
+      padding: clamp(22px, 4.5vw, 32px);
+      box-shadow: 0 30px 70px rgba(2, 6, 23, 0.55);
+      backdrop-filter: blur(18px);
+    }
+
+    .demo-hero__titles h1 {
+      margin: 0;
+      color: #f8fafc;
+      text-shadow: 0 16px 36px rgba(2, 6, 23, 0.65);
+      line-height: 1.08;
+    }
+
+    .demo-hero__titles .muted {
+      color: rgba(226, 232, 240, 0.95);
     }
 
     .demo-hero__actions {
@@ -1042,9 +1059,9 @@
       position: relative;
       padding: 22px;
       border-radius: 20px;
-      border: 1px solid rgba(226, 232, 240, 0.25);
-      background: linear-gradient(160deg, rgba(15, 23, 42, 0.55), rgba(30, 64, 175, 0.35));
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+      border: 1px solid rgba(148, 163, 184, 0.42);
+      background: linear-gradient(165deg, rgba(15, 23, 42, 0.82), rgba(30, 64, 175, 0.52));
+      box-shadow: 0 26px 60px rgba(2, 6, 23, 0.55);
       display: grid;
       gap: 8px;
       color: #f8fafc;
@@ -1069,6 +1086,7 @@
     .demo-stat-card__value {
       font-size: 1.9rem;
       font-weight: 700;
+      text-shadow: 0 10px 28px rgba(2, 6, 23, 0.6);
     }
 
     .demo-stat-card__meta {


### PR DESCRIPTION
## Summary
- add a frosted-glass container around the demo hero text for stronger contrast
- brighten key demo statistic cards and accent text with subtle shadows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d56cac2d54832ba1027999d0341973