### PR TITLE
Fix dashboard table contrast and force CSS refresh

### DIFF
--- a/public/admin-prompts.html
+++ b/public/admin-prompts.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Lion Ai | Admin Prompt Manager</title>
-  <link rel="stylesheet" href="/styles/main.css?v=20260331" />
+  <link rel="stylesheet" href="/styles/main.css?v=20260331b" />
 </head>
 <body class="admin-body">
   <div class="site admin-site">

--- a/public/demo.html
+++ b/public/demo.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Lion Ai Bot Demo Trading</title>
-  <link rel="stylesheet" href="/styles/main.css?v=20260331">
+  <link rel="stylesheet" href="/styles/main.css?v=20260331b">
 </head>
 <body data-login-url="/">
   <div class="site">

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Lion Ai Bot Smart Trading Platform</title>
-  <link rel="stylesheet" href="/styles/main.css?v=20260331">
+  <link rel="stylesheet" href="/styles/main.css?v=20260331b">
 
 </head>
 <body data-login-url="/">

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -3138,8 +3138,13 @@ footer {
 
 #dashboard table,
 #dashboard .table-wrapper {
+  background: var(--dashboard-surface);
   border: 1px solid var(--dashboard-border-soft);
   border-radius: 16px;
+}
+
+#dashboard .data-table {
+  background: transparent;
 }
 
 #dashboard thead th {
@@ -3155,6 +3160,7 @@ footer {
 }
 
 #dashboard tbody td {
+  background: transparent;
   border-bottom-color: rgba(148, 163, 184, 0.22);
 }
 


### PR DESCRIPTION
### Motivation
- Dashboard table cells were appearing as light text on white/bright backgrounds due to conflicting theme rules and cached CSS, making content unreadable. 
- The change also ensures clients receive the updated stylesheet immediately by bumping the asset version to avoid stale cache.

### Description
- Force a dark dashboard surface by setting `background: var(--dashboard-surface)` for `#dashboard table` and `#dashboard .table-wrapper` in `public/styles/main.css`.
- Prevent reintroduced white blocks by explicitly setting `#dashboard .data-table` and `#dashboard tbody td` to `background: transparent` in `public/styles/main.css`.
- Bump the CSS querystring from `v=20260331` to `v=20260331b` in `public/index.html`, `public/demo.html`, and `public/admin-prompts.html` to force browsers to refresh cached CSS.

### Testing
- Ran `npm run build` which completed successfully (no blocking errors). 
- Ran `npm test` and all tests passed (`9` tests, `0` failures). 
- Attempted to start the server with `node server.js` for end-to-end UI verification but startup failed due to missing MySQL in the environment (`ECONNREFUSED 127.0.0.1:3306`), so runtime UI validation requires a DB or demo-mode fallback.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc0d46c3e4832b9e401934d94e614d)