### PR TITLE
Fix completed/open trade logic for live and demo views

### DIFF
--- a/lib/trades.js
+++ b/lib/trades.js
@@ -23,6 +23,17 @@ function toFiniteNumber(value) {
   return Number.isFinite(num) ? num : 0;
 }
 
+function parseBuyerFlag(value) {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value === 1;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true' || normalized === '1') return true;
+    if (normalized === 'false' || normalized === '0') return false;
+  }
+  return false;
+}
+
 export function summariseCompletedTrades(trades, symbol) {
   if (!Array.isArray(trades) || !trades.length) return [];
   const { base, quote } = splitSymbolPair(symbol || '');
@@ -32,10 +43,10 @@ export function summariseCompletedTrades(trades, symbol) {
   let position = null;
 
   for (const trade of sorted) {
-    const isBuyer = Boolean(trade?.isBuyer);
+    const isBuyer = parseBuyerFlag(trade?.isBuyer);
     const price = toFiniteNumber(trade?.price);
     const qty = toFiniteNumber(trade?.qty ?? trade?.executedQty);
-    const quoteQty = toFiniteNumber(trade?.quoteQty ?? price * qty);
+    const quoteQty = toFiniteNumber(trade?.quoteQty ?? trade?.cummulativeQuoteQty ?? (price * qty));
     const commission = toFiniteNumber(trade?.commission);
     const commissionAsset = typeof trade?.commissionAsset === 'string' ? trade.commissionAsset.toUpperCase() : '';
     const timestamp = Number(trade?.time || trade?.transactTime || Date.now());

--- a/server.js
+++ b/server.js
@@ -1283,6 +1283,8 @@ async function listDemoOrders(userId, { limit = 50 } = {}) {
      FROM demo_orders o
      INNER JOIN demo_rules r ON r.id = o.rule_id
      WHERE o.user_id = ?
+       AND o.side = 'BUY'
+       AND o.linked_trade_id IS NULL
      ORDER BY o.id DESC
      LIMIT ?`,
     [userId, size]

--- a/tests/strategy.test.js
+++ b/tests/strategy.test.js
@@ -25,6 +25,27 @@ test('summariseCompletedTrades returns empty when no round trip', () => {
   assert.equal(result.length, 0);
 });
 
+
+test('summariseCompletedTrades handles string buyer flags correctly', () => {
+  const trades = [
+    { id: 1, isBuyer: 'true', price: '100', qty: '0.2', quoteQty: '20', time: 1000 },
+    { id: 2, isBuyer: 'false', price: '105', qty: '0.2', quoteQty: '21', time: 2000 }
+  ];
+  const result = summariseCompletedTrades(trades, 'SOLUSDT');
+  assert.equal(result.length, 1);
+  assert.equal(result[0].quantity, 0.2);
+  assert.equal(result[0].profit, 1);
+});
+
+test('summariseCompletedTrades does not close trade on partial sell', () => {
+  const trades = [
+    { id: 1, isBuyer: true, price: '10', qty: '2', quoteQty: '20', time: 1000 },
+    { id: 2, isBuyer: false, price: '11', qty: '1', quoteQty: '11', time: 2000 }
+  ];
+  const result = summariseCompletedTrades(trades, 'ETHUSDT');
+  assert.equal(result.length, 0);
+});
+
 test('calculatePerformanceMetrics aggregates trade outcomes', () => {
   const trades = [
     { symbol: 'BTCUSDT', profit: 10, profitPct: 5, durationMs: 60000, quoteAsset: 'USDT' },


### PR DESCRIPTION
### Motivation
- Prevent demo UI from showing orders that are actually part of completed trade cycles and avoid mis-reporting profit for live trades due to fragile parsing of exchange history.
- Make summarisation of completed trades robust to different shapes of exchange responses (`isBuyer` as string/number/boolean and missing `quoteQty`).

### Description
- Restrict demo open orders query so `listDemoOrders` only returns active buy entries that are not linked to a completed trade (`AND o.side = 'BUY' AND o.linked_trade_id IS NULL`) in `server.js`.
- Add `parseBuyerFlag` helper and use it in `summariseCompletedTrades` to correctly interpret `isBuyer` when it is boolean, numeric, or string in `lib/trades.js`.
- Fall back to `cummulativeQuoteQty` when `quoteQty` is missing to compute quote amounts reliably in `lib/trades.js`.
- Add regression tests in `tests/strategy.test.js` to cover string buyer flags and to ensure partial sells are not treated as completed round-trips.

### Testing
- Ran `npm test` and all tests passed (`11/11` subtests OK).
- Ran `npm run build` (server syntax check) which completed without errors.
- Attempted `npm start` but the server failed to start in this environment due to missing local MySQL (`ECONNREFUSED` on `127.0.0.1:3306` / `::1:3306`), so runtime integration with a DB was not exercised here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc0f5ee2ac832b93d5467c1e6b04ac)