### PR TITLE
Harden AI rule parsing and resilient client AI job handling

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2999,7 +2999,8 @@
       aiGenerateBtn.dataset.loading = 'true';
       aiGenerateBtn.disabled = true;
       updateAiFormStatus({ loading: true, message: '', type: '', stageKey: 'status.aiStagePreparingMarket', requestId, jobId: null });
-      const requestPayload = { budgetUSDT: budget, locale: state.language, requestId };
+      const selectedModel = typeof aiModelInput?.value === 'string' ? aiModelInput.value.trim() : '';
+      const requestPayload = { budgetUSDT: budget, locale: state.language, model: selectedModel || undefined, requestId };
       logAiTrace('request_payload_built', { requestId, requestPayload });
       try {
         updateAiFormStatus({ loading: true, stageKey: 'status.aiStageSendingRequest', requestId });
@@ -3021,9 +3022,17 @@
           await loadOrders(true);
           return;
         }
-        if (data.status === 'pending' && data.jobId) {
-          updateAiFormStatus({ loading: true, stageKey: 'status.aiQueued', requestId: backendRequestId, jobId: data.jobId });
-          startAiJobPolling(data.jobId, backendRequestId, data.pollIntervalMs || 2500);
+        const queuedJobId = Number(data?.jobId ?? data?.job?.id);
+        const hasQueuedJob = Number.isFinite(queuedJobId) && queuedJobId > 0;
+        if ((data.status === 'pending' || data.status === 'processing' || data.status === 'queued') && hasQueuedJob) {
+          updateAiFormStatus({ loading: true, stageKey: 'status.aiQueued', requestId: backendRequestId, jobId: queuedJobId });
+          startAiJobPolling(queuedJobId, backendRequestId, data.pollIntervalMs || 2500);
+          return;
+        }
+        if (hasQueuedJob) {
+          logAiTrace('unexpected_queue_status_fallback', { requestId: backendRequestId, status: data?.status || null, jobId: queuedJobId });
+          updateAiFormStatus({ loading: true, stageKey: 'status.aiQueued', requestId: backendRequestId, jobId: queuedJobId });
+          startAiJobPolling(queuedJobId, backendRequestId, data.pollIntervalMs || 2500);
           return;
         }
         throw new Error(translate('status.aiResponseMalformed'));

--- a/server.js
+++ b/server.js
@@ -3641,8 +3641,12 @@ app.get("/api/trades/completed", authRequired(handleAsync(async (req, res) => {
 function parseAiRoleResponse(text) {
   const resolvedText = extractLlmText(text);
   if (!resolvedText) throw new Error("AI response was empty.");
-  const maybeJsonObject = extractFirstJsonObject(resolvedText);
-  const cleaned = (maybeJsonObject || resolvedText).replace(/```json|```/gi, "").replace(/\r/g, "").trim();
+  const withoutThinking = String(resolvedText)
+    .replace(/<think[\s\S]*?<\/think>/gi, " ")
+    .replace(/^\s*thinking[\s\S]*?(?=\{|\[)/i, " ")
+    .trim();
+  const maybeJsonObject = extractFirstJsonObject(withoutThinking);
+  const cleaned = (maybeJsonObject || withoutThinking).replace(/```json|```/gi, "").replace(/\r/g, "").trim();
   if (!cleaned) throw new Error("AI response was empty.");
 
   const parseNumeric = value => {
@@ -3663,22 +3667,28 @@ function parseAiRoleResponse(text) {
 
   try {
     const parsedJson = JSON.parse(cleaned);
-    if (parsedJson && typeof parsedJson === "object" && !Array.isArray(parsedJson)) {
-      if (parsedJson.error) {
-        throw new Error(`AI error: ${parsedJson.error}`);
+    const root = Array.isArray(parsedJson) ? parsedJson.find(item => item && typeof item === "object") : parsedJson;
+    const payload = (root && typeof root === "object" && !Array.isArray(root))
+      ? (root.recommendation || root.rule || root.data || root.signal || root)
+      : null;
+    if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+      if (payload.error) {
+        throw new Error(`AI error: ${payload.error}`);
       }
-      const candidateSymbol = parsedJson.symbol || parsedJson.pair || parsedJson.ticker;
+      const candidateSymbol = payload.symbol || payload.pair || payload.ticker || payload.tradingPair || payload.trading_pair;
       if (candidateSymbol) {
         symbol = String(candidateSymbol).toUpperCase().replace(/[^A-Z0-9]/g, "");
       }
-      const candidateEntry = parsedJson.entryPrice ?? parsedJson.entry ?? parsedJson.buy;
-      const candidateExit = parsedJson.exitPrice ?? parsedJson.takeProfit ?? parsedJson.sell;
+      const candidateEntry = payload.entryPrice ?? payload.entry ?? payload.buy ?? payload.entry_price;
+      const candidateExit = payload.exitPrice ?? payload.takeProfit ?? payload.sell ?? payload.targetPrice ?? payload.target_price;
       entryPrice = parseNumeric(candidateEntry);
       exitPrice = parseNumeric(candidateExit);
-      if (typeof parsedJson.summary === "string") {
-        summary = parsedJson.summary.trim();
-      } else if (typeof parsedJson.reason === "string") {
-        summary = parsedJson.reason.trim();
+      if (typeof payload.summary === "string") {
+        summary = payload.summary.trim();
+      } else if (typeof payload.reason === "string") {
+        summary = payload.reason.trim();
+      } else if (typeof payload.rationale === "string") {
+        summary = payload.rationale.trim();
       }
     }
   } catch (err) {
@@ -3740,9 +3750,7 @@ function parseAiRoleResponse(text) {
     throw new Error("Unable to read the trading pair or price targets from the AI response.");
   }
 
-  if (!symbol.endsWith("USDT") && symbol.includes("/")) {
-    symbol = symbol.replace(/\//g, "");
-  }
+  symbol = symbol.replace(/[\/\-_]/g, "");
 
   if (symbol.length < 6) {
     throw new Error("The trading pair suggested by the AI is not valid for spot trading.");


### PR DESCRIPTION
### Motivation
- LLM providers sometimes emit wrapped/preface text or nested/array JSON shapes that cause the AI rule parser to fail with "invalid response payload." 
- The frontend could also receive variant queue responses (different `status` values or `job` nesting) and treat valid queued jobs as malformed.

### Description
- Server: improved `parseAiRoleResponse` to strip `<think>...</think>` and leading "thinking" preface, extract the first JSON object from the cleaned text, and prefer that for parsing. 
- Server: tolerate arrays and nested payloads by locating a root object and checking common container keys (`recommendation`, `rule`, `data`, `signal`) before extracting fields. 
- Server: accept additional field aliases (`tradingPair`, `trading_pair`, `entry_price`, `target_price`, `rationale`) and normalize symbol separators by removing `/`, `-`, and `_` before validation. 
- Client: send the selected model in the `POST /api/ai-role` payload via the UI and make queue handling resilient by accepting `jobId` or `job.id`, treating `pending`/`processing`/`queued` as valid queued states, and falling back to polling whenever a valid job id is present.

### Testing
- Ran `npm test` and all tests passed (`11/11`). 
- Ran `npm run build` (`node --check server.js`) and it completed without errors. 
- Attempted `npm start` but the server failed to start due to missing MySQL in the environment (`ECONNREFUSED` to `127.0.0.1:3306` / `::1:3306`), which is an environment issue and not a code failure. 
- Noted an `npm` warning `Unknown env config "http-proxy"` which is non-blocking; recommended removing or correcting the `http-proxy` npm config (e.g., via `.npmrc` or env) to avoid future npm major-version issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2bea3cdb0832b83c8cb319bed1ab2)