### PR TITLE
Add scalping bot mode (backend engine + UI) with fee-aware execution

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -415,6 +415,35 @@
         </article>
 
         <article class="card">
+          <h2 data-i18n="scalping.title">Scalping bot</h2>
+          <p data-i18n="scalping.description">Fast limit buy/sell rounds with fee-aware net profit per cycle.</p>
+          <form id="scalpingForm">
+            <div class="form-row">
+              <div>
+                <label for="scalpSymbol" data-i18n="scalping.symbolLabel">Pair</label>
+                <input id="scalpSymbol" required data-i18n-placeholder="scalping.symbolPlaceholder">
+              </div>
+              <div>
+                <label for="scalpBudget" data-i18n="scalping.budgetLabel">Bot budget (USDT)</label>
+                <input id="scalpBudget" type="number" step="0.01" min="0" required data-i18n-placeholder="scalping.budgetPlaceholder">
+              </div>
+            </div>
+            <div class="form-row">
+              <div>
+                <label for="scalpNetProfit" data-i18n="scalping.netProfitLabel">Net profit per cycle (USDT)</label>
+                <input id="scalpNetProfit" type="number" step="0.0001" min="0" required data-i18n-placeholder="scalping.netProfitPlaceholder">
+              </div>
+              <div>
+                <label for="scalpFeePct" data-i18n="scalping.feeLabel">Binance fee per side %</label>
+                <input id="scalpFeePct" type="number" step="0.0001" min="0" value="0.1" required data-i18n-placeholder="scalping.feePlaceholder">
+              </div>
+            </div>
+            <button class="btn primary" type="submit" data-i18n="scalping.add">Add scalping bot</button>
+            <p class="muted small" data-i18n="scalping.helper">The bot keeps running and re-enters after each filled sell order until you disable or delete it.</p>
+          </form>
+        </article>
+
+        <article class="card">
           <h2 data-i18n="ai.title">AI-powered rule</h2>
           <p data-i18n="ai.description">Request a market-ready spot strategy backed by real-time research.</p>
           <div class="plan-warning" id="aiRestriction"></div>
@@ -447,6 +476,27 @@
                 <th data-i18n="manual.table.budget">Budget</th>
                 <th data-i18n="manual.table.status">Status</th>
                 <th data-i18n="manual.table.actions">Actions</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="card table-card">
+        <div class="table-header">
+          <h2 data-i18n="scalping.tableTitle">Scalping bots</h2>
+          <span class="pill" id="scalpingCount">0</span>
+        </div>
+        <div class="table-wrapper">
+          <table class="data-table" id="scalpingRulesTable">
+            <thead>
+              <tr>
+                <th data-i18n="scalping.table.rule">Rule</th>
+                <th data-i18n="scalping.table.strategy">Scalping setup</th>
+                <th data-i18n="scalping.table.budget">Budget</th>
+                <th data-i18n="scalping.table.status">Status</th>
+                <th data-i18n="scalping.table.actions">Actions</th>
               </tr>
             </thead>
             <tbody></tbody>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -144,6 +144,28 @@
             actions: "Actions"
           }
         },
+        scalping: {
+          title: "Scalping bot",
+          description: "Fast limit buy/sell rounds with fee-aware net profit per cycle.",
+          symbolLabel: "Pair",
+          symbolPlaceholder: "Example: BTCUSDT",
+          budgetLabel: "Bot budget (USDT)",
+          budgetPlaceholder: "50",
+          netProfitLabel: "Net profit per cycle (USDT)",
+          netProfitPlaceholder: "0.05",
+          feeLabel: "Binance fee per side %",
+          feePlaceholder: "0.1",
+          add: "Add scalping bot",
+          helper: "The bot keeps running and re-enters after each filled sell order until you disable or delete it.",
+          tableTitle: "Scalping bots",
+          table: {
+            rule: "Rule",
+            strategy: "Scalping setup",
+            budget: "Budget",
+            status: "Status",
+            actions: "Actions"
+          }
+        },
         ai: {
           title: "AI-powered rule",
           description: "Request a market-ready spot strategy backed by real-time research.",
@@ -236,6 +258,12 @@
           macdBearish: "Bearish",
           empty: "No manual rules yet."
         },
+        scalpingRules: {
+          netProfitLabel: "Net profit",
+          feeLabel: "Fee/side",
+          calcLabel: "Auto target",
+          empty: "No scalping bots yet."
+        },
         aiRules: {
           summaryToggle: "View AI summary",
           empty: "No AI rules yet."
@@ -256,6 +284,7 @@
           keysSaved: "API keys saved.",
           keysRemoved: "Connection removed.",
           manualAdded: "Manual rule added.",
+          scalpingAdded: "Scalping bot added.",
           manualSynced: "Rules synced with engine.",
           aiGenerated: "AI rule generated successfully.",
           aiGenerating: "Generating your AI rule and validating it...",
@@ -290,6 +319,7 @@
           rulePaused: "Rule paused.",
           ruleDeleted: "Rule deleted.",
           aiBudgetInvalid: "Enter a valid AI budget.",
+          scalpingInvalid: "Enter valid scalping settings.",
           manualLocked: "Manual rules are disabled for your current plan.",
           aiLocked: "AI rules are disabled for your current plan.",
           manualLimit: "Your plan allows up to {{count}} manual rules.",
@@ -485,6 +515,28 @@
             actions: "إجراءات"
           }
         },
+        scalping: {
+          title: "بوت سكالبينج",
+          description: "دورات شراء/بيع سريعة بأوامر ليمت مع احتساب الرسوم وصافي الربح لكل دورة.",
+          symbolLabel: "الزوج",
+          symbolPlaceholder: "مثال: BTCUSDT",
+          budgetLabel: "ميزانية البوت (USDT)",
+          budgetPlaceholder: "50",
+          netProfitLabel: "صافي الربح لكل دورة (USDT)",
+          netProfitPlaceholder: "0.05",
+          feeLabel: "رسوم بينانس لكل جهة %",
+          feePlaceholder: "0.1",
+          add: "إضافة بوت سكالبينج",
+          helper: "يستمر البوت في العمل ويعيد الدخول بعد كل بيع مكتمل حتى توقفه أو تحذفه.",
+          tableTitle: "بوتات السكالبينج",
+          table: {
+            rule: "القاعدة",
+            strategy: "إعداد السكالبينج",
+            budget: "الميزانية",
+            status: "الحالة",
+            actions: "إجراءات"
+          }
+        },
         ai: {
           title: "قاعدة بالذكاء الاصطناعي",
           description: "اطلب إستراتيجية تداول فورية مدعومة ببحث لحظي.",
@@ -577,6 +629,12 @@
           macdBearish: "هابط",
           empty: "لا توجد قواعد يدوية بعد."
         },
+        scalpingRules: {
+          netProfitLabel: "صافي الربح",
+          feeLabel: "الرسوم/جهة",
+          calcLabel: "الهدف المحسوب",
+          empty: "لا توجد بوتات سكالبينج بعد."
+        },
         aiRules: {
           summaryToggle: "عرض ملخص الذكاء الاصطناعي",
           empty: "لا توجد قواعد ذكاء اصطناعي بعد."
@@ -597,6 +655,7 @@
           keysSaved: "تم حفظ مفاتيح API.",
           keysRemoved: "تم إلغاء الربط.",
           manualAdded: "تمت إضافة القاعدة اليدوية.",
+          scalpingAdded: "تمت إضافة بوت السكالبينج.",
           manualSynced: "تمت مزامنة القواعد مع المحرك.",
           aiGenerated: "تم توليد قاعدة ذكاء اصطناعي بنجاح.",
           aiGenerating: "جارٍ توليد قاعدة الذكاء الاصطناعي والتحقق منها...",
@@ -631,6 +690,7 @@
           rulePaused: "تم إيقاف القاعدة.",
           ruleDeleted: "تم حذف القاعدة.",
           aiBudgetInvalid: "أدخل ميزانية صحيحة للذكاء الاصطناعي.",
+          scalpingInvalid: "أدخل إعدادات سكالبينج صحيحة.",
           manualLocked: "القواعد اليدوية غير متاحة في باقتك الحالية.",
           aiLocked: "قواعد الذكاء الاصطناعي غير متاحة في باقتك الحالية.",
           manualLimit: "باقتك تسمح حتى {{count}} من القواعد اليدوية.",
@@ -768,6 +828,7 @@
     const apiKeysForm = document.getElementById('apiKeysForm');
     const removeKeysBtn = document.getElementById('removeKeys');
     const manualForm = document.getElementById('manualForm');
+    const scalpingForm = document.getElementById('scalpingForm');
     const syncRulesBtn = document.getElementById('syncRules');
     const aiForm = document.getElementById('aiForm');
     const aiGenerateBtn = document.getElementById('aiGenerate');
@@ -775,11 +836,13 @@
     const aiBudgetInput = document.getElementById('aiBudget');
     const aiModelInput = document.getElementById('aiModel');
     const manualTableBody = document.querySelector('#manualRulesTable tbody');
+    const scalpingTableBody = document.querySelector('#scalpingRulesTable tbody');
     const aiTableBody = document.querySelector('#aiRulesTable tbody');
     const ordersTableBody = document.querySelector('#ordersTable tbody');
     const completedTradesList = document.getElementById('completedTradesList');
     const completedTradesNotice = document.getElementById('completedTradesNotice');
     const manualCountEl = document.getElementById('manualCount');
+    const scalpingCountEl = document.getElementById('scalpingCount');
     const aiCountEl = document.getElementById('aiCount');
     const manualHighlightCount = document.getElementById('manualHighlightCount');
     const manualHighlightMeta = document.getElementById('manualHighlightMeta');
@@ -1194,6 +1257,7 @@
 
     function renderTables() {
       renderManualRules();
+      renderScalpingRules();
       renderAiRules();
       announceRuleErrors();
       applyEntitlementsUI();
@@ -1602,6 +1666,59 @@
       }
     }
 
+    function renderScalpingRules() {
+      const scalpingRules = state.rules.filter(r => (r.type || '').toLowerCase() === 'scalping');
+      const ent = state.entitlements || {};
+      const manualLimit = Number(ent?.manualLimit);
+      const manualEnabled = Boolean(ent && ent.manualEnabled);
+      const activeManual = state.rules.filter(r => {
+        const type = (r.type || '').toLowerCase();
+        return (type === 'manual' || type === 'scalping') && r.enabled;
+      }).length;
+      scalpingTableBody.innerHTML = '';
+      const loading = state.isRulesLoading && !scalpingRules.length;
+      const errorMessage = resolveUiMessage(state.rulesError, 'status.rulesError');
+      if (loading) {
+        appendTablePlaceholder(scalpingTableBody, 5, translate('status.rulesLoading'), { loading: true });
+        return;
+      }
+      if (errorMessage && !scalpingRules.length) {
+        appendTablePlaceholder(scalpingTableBody, 5, errorMessage, { variant: 'error' });
+        return;
+      }
+      if (!scalpingRules.length) {
+        appendTablePlaceholder(scalpingTableBody, 5, translate('scalpingRules.empty'));
+        return;
+      }
+      for (const rule of scalpingRules) {
+        const tr = document.createElement('tr');
+        const settings = rule.indicatorSettings && typeof rule.indicatorSettings === 'object' ? rule.indicatorSettings : {};
+        const netProfit = Number(settings.netProfitQuote);
+        const feeRate = Number(settings.feeRatePct);
+        const capReached = Number.isFinite(manualLimit) && manualLimit > 0 && activeManual >= manualLimit;
+        const toggleDisabled = !manualEnabled || (!rule.enabled && capReached);
+        tr.innerHTML = `
+          <td data-label="${escapeHtml(translate('scalping.table.rule'))}"><div class="symbol">${escapeHtml(rule.symbol)}</div></td>
+          <td data-label="${escapeHtml(translate('scalping.table.strategy'))}">
+            <div class="muted small">${escapeHtml(translate('scalpingRules.netProfitLabel'))}: <strong>${escapeHtml(formatCurrency(netProfit))}</strong></div>
+            <div class="muted small">${escapeHtml(translate('scalpingRules.feeLabel'))}: ${escapeHtml(formatPercent(feeRate))}</div>
+            <div class="muted small">${escapeHtml(translate('scalpingRules.calcLabel'))}: ${escapeHtml(translate('manual.partialsLabel'))} 100%</div>
+          </td>
+          <td data-label="${escapeHtml(translate('scalping.table.budget'))}">${formatCurrency(rule.budgetUSDT)}</td>
+          <td data-label="${escapeHtml(translate('scalping.table.status'))}">
+            <label class="switch">
+              <input type="checkbox" data-action="toggle" data-id="${rule.id}" ${rule.enabled ? 'checked' : ''} ${toggleDisabled ? 'disabled' : ''}>
+              <span class="slider"></span>
+            </label>
+          </td>
+          <td data-label="${escapeHtml(translate('scalping.table.actions'))}">
+            <button class="btn-text danger" data-action="delete" data-id="${rule.id}">${escapeHtml(translate('common.delete'))}</button>
+          </td>
+        `;
+        scalpingTableBody.appendChild(tr);
+      }
+    }
+
     function renderOrders(rows) {
       currentOrdersCache = Array.isArray(rows) ? rows : [];
       ordersTableBody.innerHTML = '';
@@ -1889,7 +2006,11 @@
       const aiEnabled = Boolean(state.token && ent && ent.aiEnabled);
       const manualLimit = Number(ent?.manualLimit);
       const aiLimit = Number(ent?.aiLimit);
-      const activeManual = state.rules.filter(r => (r.type || '').toLowerCase() === 'manual' && r.enabled).length;
+      const activeManual = state.rules.filter(r => {
+        const type = (r.type || '').toLowerCase();
+        return (type === 'manual' || type === 'scalping') && r.enabled;
+      }).length;
+      const activeScalping = state.rules.filter(r => (r.type || '').toLowerCase() === 'scalping' && r.enabled).length;
       const activeAi = state.rules.filter(r => (r.type || '').toLowerCase() === 'ai' && r.enabled).length;
       const manualCapReached = manualEnabled && Number.isFinite(manualLimit) && manualLimit >= 0 && activeManual >= manualLimit;
       const aiCapReached = aiEnabled && Number.isFinite(aiLimit) && aiLimit >= 0 && activeAi >= aiLimit;
@@ -1899,6 +2020,9 @@
       }
       if (aiCountEl) {
         aiCountEl.textContent = formatUsageCount(activeAi, aiLimit);
+      }
+      if (scalpingCountEl) {
+        scalpingCountEl.textContent = formatUsageCount(activeScalping, manualLimit);
       }
 
       if (manualHighlightCount) {
@@ -1955,6 +2079,16 @@
           input.disabled = !manualEnabled;
         });
         const submit = manualForm.querySelector('button[type="submit"]');
+        if (submit) {
+          submit.disabled = !manualEnabled || manualCapReached;
+        }
+      }
+      if (scalpingForm) {
+        const inputs = scalpingForm.querySelectorAll('input, select');
+        inputs.forEach(input => {
+          input.disabled = !manualEnabled;
+        });
+        const submit = scalpingForm.querySelector('button[type="submit"]');
         if (submit) {
           submit.disabled = !manualEnabled || manualCapReached;
         }
@@ -2847,7 +2981,10 @@
         return;
       }
       const manualLimit = Number(ent?.manualLimit);
-      const activeManual = state.rules.filter(r => (r.type || '').toLowerCase() === 'manual' && r.enabled).length;
+      const activeManual = state.rules.filter(r => {
+        const type = (r.type || '').toLowerCase();
+        return (type === 'manual' || type === 'scalping') && r.enabled;
+      }).length;
       if (Number.isFinite(manualLimit) && manualLimit > 0 && activeManual >= manualLimit) {
         setStatus(translate('status.manualLimit', { count: manualLimit }), 'error');
         return;
@@ -2887,6 +3024,54 @@
       }
     }
 
+    async function addScalpingRule(event) {
+      event.preventDefault();
+      const ent = state.entitlements || {};
+      if (!ent || !ent.plan || ent.manualEnabled === false) {
+        setStatus(translate('status.manualLocked'), 'error');
+        return;
+      }
+      const manualLimit = Number(ent?.manualLimit);
+      const activeManual = state.rules.filter(r => {
+        const type = (r.type || '').toLowerCase();
+        return (type === 'manual' || type === 'scalping') && r.enabled;
+      }).length;
+      if (Number.isFinite(manualLimit) && manualLimit > 0 && activeManual >= manualLimit) {
+        setStatus(translate('status.manualLimit', { count: manualLimit }), 'error');
+        return;
+      }
+      const symbol = document.getElementById('scalpSymbol')?.value?.trim()?.toUpperCase();
+      const budgetUSDT = Number(document.getElementById('scalpBudget')?.value);
+      const netProfitQuote = Number(document.getElementById('scalpNetProfit')?.value);
+      const feeRatePct = Number(document.getElementById('scalpFeePct')?.value);
+      if (!symbol || !(budgetUSDT > 0) || !(netProfitQuote > 0) || !(feeRatePct > 0)) {
+        setStatus(translate('status.scalpingInvalid'), 'error');
+        return;
+      }
+      const rule = {
+        id: generateId(),
+        type: 'scalping',
+        symbol,
+        budgetUSDT,
+        enabled: true,
+        createdAt: Date.now(),
+        indicatorSettings: {
+          mode: 'scalping',
+          feeRatePct,
+          netProfitQuote
+        }
+      };
+      const next = [...state.rules, rule];
+      try {
+        await persistAll(next, { text: translate('status.scalpingAdded'), type: 'success' });
+        scalpingForm.reset();
+        const feeInput = document.getElementById('scalpFeePct');
+        if (feeInput) feeInput.value = '0.1';
+      } catch (err) {
+        setStatus(err.message, 'error');
+      }
+    }
+
     async function syncRules() {
       try {
         const response = await api('/api/rules/sync', { method: 'POST' });
@@ -2908,12 +3093,12 @@
         const ent = state.entitlements || {};
         const type = (rule.type || '').toLowerCase();
         if (!ent || !ent.plan) {
-          const messageKey = type === 'manual' ? 'status.manualLocked' : 'status.aiLocked';
+          const messageKey = (type === 'manual' || type === 'scalping') ? 'status.manualLocked' : 'status.aiLocked';
           setStatus(translate(messageKey), 'error');
           renderTables();
           return;
         }
-        if (type === 'manual') {
+        if (type === 'manual' || type === 'scalping') {
           if (ent.manualEnabled === false) {
             setStatus(translate('status.manualLocked'), 'error');
             renderTables();
@@ -2921,7 +3106,10 @@
           }
           const manualLimit = Number(ent?.manualLimit);
           if (Number.isFinite(manualLimit) && manualLimit > 0) {
-            const activeManual = state.rules.filter(r => (r.type || '').toLowerCase() === 'manual' && r.enabled).length;
+            const activeManual = state.rules.filter(r => {
+              const nextType = (r.type || '').toLowerCase();
+              return (nextType === 'manual' || nextType === 'scalping') && r.enabled;
+            }).length;
             const nextActive = rule.enabled ? activeManual : activeManual + 1;
             if (nextActive > manualLimit) {
               setStatus(translate('status.manualLimit', { count: manualLimit }), 'error');
@@ -3138,6 +3326,7 @@
     apiKeysForm.addEventListener('submit', submitApiKeys);
     removeKeysBtn.addEventListener('click', removeApiKeys);
     manualForm.addEventListener('submit', addManualRule);
+    if (scalpingForm) scalpingForm.addEventListener('submit', addScalpingRule);
     syncRulesBtn.addEventListener('click', syncRules);
     aiForm.addEventListener('submit', generateAiRule);
     if (alertSettingsForm) alertSettingsForm.addEventListener('submit', submitAlertSettings);

--- a/server.js
+++ b/server.js
@@ -2640,7 +2640,7 @@ function normalizeRules(input) {
     rule.symbol = cleanSymbol;
 
     const rawType = typeof rule.type === "string" ? rule.type.toLowerCase() : "";
-    let type = rawType === "ai" ? "ai" : "manual";
+    let type = rawType === "ai" ? "ai" : rawType === "scalping" ? "scalping" : "manual";
     if (!rawType) {
       if (!rule.dipPct && !rule.tpPct && rule.entryPrice && rule.exitPrice) {
         type = "ai";
@@ -2722,6 +2722,30 @@ function normalizeRules(input) {
       }
       rule.entryPrice = 0;
       rule.exitPrice = 0;
+    } else if (rule.type === "scalping") {
+      const settingsRaw = rule.indicatorSettings && typeof rule.indicatorSettings === "object"
+        ? rule.indicatorSettings
+        : {};
+      const feeRatePct = Number(settingsRaw.feeRatePct);
+      const netProfitQuote = Number(
+        settingsRaw.netProfitQuote
+        ?? settingsRaw.netProfitUSDT
+        ?? settingsRaw.netProfit
+      );
+      const settings = {
+        mode: "scalping",
+        feeRatePct: Number.isFinite(feeRatePct) && feeRatePct > 0 ? Number(feeRatePct.toFixed(4)) : 0.1,
+        netProfitQuote: Number.isFinite(netProfitQuote) && netProfitQuote > 0 ? Number(netProfitQuote.toFixed(8)) : 0.05
+      };
+      if (JSON.stringify(settings) !== JSON.stringify(rule.indicatorSettings || null)) {
+        mutated = true;
+      }
+      rule.indicatorSettings = settings;
+      rule.dipPct = 0;
+      rule.tpPct = 0;
+      rule.entryPrice = 0;
+      rule.exitPrice = 0;
+      rule.takeProfitSteps = [];
     } else {
       const entry = Number(rule.entryPrice);
       if (Number.isFinite(entry)) {
@@ -2800,7 +2824,7 @@ function applyEntitlementsToRules(rules, entitlements) {
   const aiIndexes = [];
   result.forEach((rule, index) => {
     const type = (rule.type || "").toLowerCase();
-    if (type === "manual") manualIndexes.push(index);
+    if (type === "manual" || type === "scalping") manualIndexes.push(index);
     else if (type === "ai") aiIndexes.push(index);
   });
 
@@ -2855,6 +2879,12 @@ function applyEntitlementsToRules(rules, entitlements) {
 
 function countActiveRules(rules, type) {
   const target = (type || "").toLowerCase();
+  if (target === "manual") {
+    return rules.filter(rule => {
+      const ruleType = (rule.type || "").toLowerCase();
+      return (ruleType === "manual" || ruleType === "scalping") && rule.enabled;
+    }).length;
+  }
   return rules.filter(rule => (rule.type || "").toLowerCase() === target && rule.enabled).length;
 }
 

--- a/strategy.js
+++ b/strategy.js
@@ -657,11 +657,40 @@ function findRecentBuy(trades, state, rule, targetPrice, filters) {
   return null;
 }
 
+function resolveRuleType(rule) {
+  const raw = String(rule?.type || "manual").toLowerCase();
+  if (raw === "ai") return "ai";
+  if (raw === "scalping") return "scalping";
+  return "manual";
+}
+
+function buildScalpingProfile(rule, qty, buyTarget, filters) {
+  const settings = rule?.indicatorSettings && typeof rule.indicatorSettings === "object"
+    ? rule.indicatorSettings
+    : {};
+  const feeRatePct = Number(settings.feeRatePct);
+  const feeRate = Number.isFinite(feeRatePct) && feeRatePct > 0 ? feeRatePct / 100 : 0.001;
+  const netProfitQuote = Number(settings.netProfitQuote ?? settings.netProfitUSDT ?? settings.netProfit);
+  if (!(qty > 0) || !(buyTarget > 0) || !(netProfitQuote > 0)) return null;
+  if (feeRate >= 0.99) return null;
+  const requiredSellPrice = (buyTarget * (1 + feeRate) + (netProfitQuote / qty)) / (1 - feeRate);
+  const sellTarget = roundToTick(requiredSellPrice, filters.tickSize);
+  if (!(sellTarget > buyTarget)) return null;
+  const grossPct = ((sellTarget - buyTarget) / buyTarget) * 100;
+  if (!(grossPct > 0)) return null;
+  return {
+    feeRatePct: Number((feeRate * 100).toFixed(4)),
+    netProfitQuote,
+    sellTarget,
+    grossPct
+  };
+}
+
 async function processRule({ binance, rule, caches, userId, hooks, stateManager }) {
   const symbol = (rule.symbol || "").toUpperCase();
   if (!symbol || rule.enabled === false) return;
 
-  const type = String(rule.type || "manual").toLowerCase() === "ai" ? "ai" : "manual";
+  const type = resolveRuleType(rule);
   const budget = Number(rule.budgetUSDT);
   if (!(budget > 0)) return;
 
@@ -693,6 +722,15 @@ async function processRule({ binance, rule, caches, userId, hooks, stateManager 
     const currentPrice = await getCurrentPrice(symbol, binance, caches);
     if (!(currentPrice > 0)) return;
     buyTarget = roundToTick(currentPrice * (1 - dipPct / 100), filters.tickSize);
+  } else if (type === "scalping") {
+    const settings = rule?.indicatorSettings && typeof rule.indicatorSettings === "object"
+      ? rule.indicatorSettings
+      : {};
+    const feeRatePct = Number(settings.feeRatePct);
+    const feeRate = Number.isFinite(feeRatePct) && feeRatePct > 0 ? feeRatePct / 100 : 0.001;
+    const currentPrice = await getCurrentPrice(symbol, binance, caches);
+    if (!(currentPrice > 0)) return;
+    buyTarget = roundToTick(currentPrice * (1 - feeRate), filters.tickSize);
   } else {
     buyTarget = roundToTick(Number(rule.entryPrice), filters.tickSize);
   }
@@ -701,6 +739,16 @@ async function processRule({ binance, rule, caches, userId, hooks, stateManager 
   let qty = floorToStep(budget / buyTarget, filters.stepSize);
   if (qty < filters.minQty || qty * buyTarget < filters.minNotional) {
     return;
+  }
+  let effectiveRule = rule;
+  if (type === "scalping") {
+    const profile = buildScalpingProfile(rule, qty, buyTarget, filters);
+    if (!profile) return;
+    effectiveRule = {
+      ...rule,
+      tpPct: profile.grossPct,
+      takeProfitSteps: [{ profitPct: profile.grossPct, portionPct: 100 }]
+    };
   }
 
   const reportIssue = async (code, message) => {
@@ -777,7 +825,7 @@ async function processRule({ binance, rule, caches, userId, hooks, stateManager 
 
   const newBuyTrade = findRecentBuy(trades, state, rule, buyTarget, filters);
   if (newBuyTrade) {
-    const nextState = buildInitialStateFromTrade(rule, newBuyTrade, filters);
+    const nextState = buildInitialStateFromTrade(effectiveRule, newBuyTrade, filters);
     if (nextState) {
       state = nextState;
       await stateManager.save(rule.id, state);
@@ -852,7 +900,7 @@ async function processRule({ binance, rule, caches, userId, hooks, stateManager 
   await ensureTakeProfitOrders({
     binance,
     symbol,
-    rule,
+    rule: effectiveRule,
     state,
     orders: refreshedOrders,
     filters,

--- a/tests/strategy.test.js
+++ b/tests/strategy.test.js
@@ -283,3 +283,81 @@ test('manual rules honour indicator entry and exit filters', async () => {
   await processor.processSnapshot(snapshot);
   assert.equal(placeLimitCalls.filter(c => c.side === 'SELL').length, 1, 'sell should be placed once MACD exit passes');
 });
+
+test('scalping rules place fee-aware buy and sell targets', async () => {
+  const { createEngineProcessor } = await strategyModulePromise;
+  const savedStates = new Map();
+  const processor = createEngineProcessor({
+    loadRuleState: async ({ ruleId }) => savedStates.get(ruleId) || null,
+    saveRuleState: async ({ ruleId, state }) => {
+      savedStates.set(ruleId, state ? JSON.parse(JSON.stringify(state)) : null);
+    }
+  });
+
+  const now = Date.now();
+  const buyTrade = { id: 99, isBuyer: true, qty: '1', price: '99.9', time: now };
+  const placeLimitCalls = [];
+  const openOrdersStore = [];
+  let nextOrderId = 1;
+  let tradeCalls = 0;
+  const fakeBinance = {
+    exchangeInfo: async () => ({
+      symbols: [{
+        symbol: 'BTCUSDT',
+        filters: [
+          { filterType: 'LOT_SIZE', stepSize: '0.001', minQty: '0.001' },
+          { filterType: 'PRICE_FILTER', tickSize: '0.01' },
+          { filterType: 'MIN_NOTIONAL', minNotional: '10' }
+        ]
+      }]
+    }),
+    avgPrice: async () => ({ price: '100' }),
+    openOrders: async () => openOrdersStore.map(order => ({ ...order })),
+    myTrades: async () => {
+      tradeCalls += 1;
+      return tradeCalls >= 2 ? [buyTrade] : [];
+    },
+    placeLimit: async (symbol, side, qty, price, options = {}) => {
+      placeLimitCalls.push({ symbol, side, qty, price, options });
+      openOrdersStore.push({
+        clientOrderId: options?.clientOrderId || `ID${nextOrderId}`,
+        orderId: String(nextOrderId),
+        side,
+        price: String(price),
+        origQty: String(qty),
+        quantity: String(qty)
+      });
+      nextOrderId += 1;
+    },
+    cancelOrder: async () => {},
+    placeStopLossLimit: async () => {}
+  };
+
+  const snapshot = {
+    userId: 1,
+    binance: fakeBinance,
+    rules: [{
+      id: 'scalp-1',
+      type: 'scalping',
+      symbol: 'BTCUSDT',
+      budgetUSDT: 100,
+      enabled: true,
+      createdAt: now - 5000,
+      indicatorSettings: {
+        mode: 'scalping',
+        feeRatePct: 0.1,
+        netProfitQuote: 0.1
+      }
+    }]
+  };
+
+  await processor.processSnapshot(snapshot);
+  await processor.processSnapshot(snapshot);
+
+  const buyOrder = placeLimitCalls.find(call => call.side === 'BUY');
+  const sellOrder = placeLimitCalls.find(call => call.side === 'SELL');
+  assert.ok(buyOrder);
+  assert.ok(sellOrder);
+  assert.equal(buyOrder.price, 99.9);
+  assert.ok(sellOrder.price > buyOrder.price);
+});


### PR DESCRIPTION
### Motivation
- Introduce a third rule type (scalping) that runs fast limit buy/sell cycles and targets a user-defined net profit per cycle after fees.
- Keep subscription/entitlement semantics consistent by counting scalping bots against manual rule limits and reusing existing rule lifecycle handling.

### Description
- Add a new `scalping` rule type supported end-to-end: rules normalization and storage in `server.js` now accept `type: "scalping"` and normalise scalping settings into `indicatorSettings` (fee and net profit) and default fields.
- Implement scalping logic in `strategy.js` with `resolveRuleType`, `buildScalpingProfile` and engine changes so the processor places a fee-aware BUY limit below market and computes a SELL target that guarantees the configured net profit after buy+sell fees, then creates a single take-profit step.
- Extend entitlement handling so scalping rules are grouped with manual rules for limits and enable/disable flows (`applyEntitlementsToRules`, `countActiveRules`).
- Add UI: form, translations (EN/AR), table, and client logic in `public/index.html` and `public/js/app.js` to create, list, toggle and delete scalping bots and reuse existing persisting/syncing flows.
- Include a unit test in `tests/strategy.test.js` that validates scalping buy/sell placement is fee-aware and consistent with expectations.

### Testing
- Ran unit tests with `npm test`, all tests passed (12/12). 
- Performed static/server checks with `npm run build` and `node --check public/js/app.js`, both succeeded (build check passed; no syntax errors reported).
- Attempted to start the full app with `npm start` but server startup failed due to missing local MySQL (`ECONNREFUSED ::1:3306`), so end-to-end runtime validation against a live DB was not possible in this environment.
- Attempted headless UI capture but Playwright was not installed in the environment (`playwright-missing`), so screenshots were not produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4b4ffde4c832b97dad835639b5da8)